### PR TITLE
API result table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 0.3.0 - in progress
+## 0.4.0 - in progress
+
+### Added
+
+### Changed
+- Changed the table view to be shown as a modal view.
+- Updated format of API results (e.g., use consistent letter cases and use scientific notations for long numbers).
+
+## 0.3.0 - 05/27/20
 
 ### Added
 - Added real data (quality score for each sample) for quantitative bar charts.

--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -6,15 +6,13 @@ import { CLOSE } from './utils/icons';
 
 /**
  * Component for data table.
- * @prop {number} margin The left position of this view. // TODO:
- * @prop {number} top The top position of this view.
- * @prop {number} width The width of this view.
- * @prop {number} height The height of this view.
+ * @prop {number} margin The gap between the inner table and the viewport.
  * @prop {array} rows Array of rows to render data table.
  * @prop {array} columns Array of column names in data table.
  * @prop {string} title A title for the table. Optional.
  * @prop {string} subtitle A subtitle for the table. Optional.
  * @prop {boolean} isLoading Whether the data is still loading, in which case show a spinner.
+ * @prop {array} expoNotations A list of columns names that need to use exponential notations.
  * @prop {(function|null)} onCheckRows If a function is provided, a checkbox will be shown for each row.
  * On change of any checkbox elements, an array of all checked row objects will be passed to the function. By default, null.
  */

--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -26,6 +26,7 @@ export default function DataTable(props) {
         subtitle,
         isLoading = false,
         onCheckRows = null,
+        expoNotations = [],
         onClose
     } = props;
 
@@ -65,7 +66,11 @@ export default function DataTable(props) {
             </td>
         ) : null);
         const dataCells = columns.map((c, j) => {
-            return <td key={j}>{d[c]}</td>;
+            return (
+                <td key={j}>
+                    {expoNotations.includes(c) && +d[c] ? Number.parseFloat(d[c]).toExponential(2) : d[c]}
+                </td>
+            );
         });
         return <tr key={i}>{checkboxCell}{dataCells}</tr>;
     });
@@ -78,7 +83,14 @@ export default function DataTable(props) {
                 width: `calc(100% - ${margin * 2}px)`,
                 height: `calc(100% - ${margin * 2}px)`
             }}>
-            <h4 className="chw-table-title">{title}</h4>
+            <h4 className="cisvis-table-title">{title}</h4>
+            <span className="cisvis-table-subtitle">
+                {isLoading ? (
+                    <span className="cisvis-progress-ring" />
+                ) : (subtitle ? (
+                    <b>{subtitle}</b>
+                ) : null)}
+            </span>
             <span style={{ verticalAlign: "middle", display: "inline-block" }}>
                 <svg
                     className={`chw-button`}
@@ -90,13 +102,6 @@ export default function DataTable(props) {
                     <path d={CLOSE.path} fill="currentColor"/>
                 </svg>
             </span>
-            <span className="chw-table-subtitle">
-                {isLoading ? (
-                    <span className="chw-progress-ring" />
-                ) : (subtitle ? (
-                    <b>{subtitle}</b>
-                ) : null)}
-            </span>
             <div
                 style={{
                     height: "calc(100% - 40px)",
@@ -105,7 +110,7 @@ export default function DataTable(props) {
             >
                 {bodyRows ? (
                     <form>
-                        <table className="chw-table">
+                        <table className="cisvis-table">
                             <thead>
                                 {headRow}
                             </thead>

--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -6,7 +6,7 @@ import { CLOSE } from './utils/icons';
 
 /**
  * Component for data table.
- * @prop {number} left The left position of this view.
+ * @prop {number} margin The left position of this view. // TODO:
  * @prop {number} top The top position of this view.
  * @prop {number} width The width of this view.
  * @prop {number} height The height of this view.
@@ -20,7 +20,7 @@ import { CLOSE } from './utils/icons';
  */
 export default function DataTable(props) {
     const {
-        left, top, width, height,
+        margin,
         rows = [], columns = [],
         title = "Data Preview",
         subtitle,
@@ -71,12 +71,13 @@ export default function DataTable(props) {
     });
 
     return (
-        <div
-            style={{
-                position: "absolute",
-                left, top, width, height
-            }}
-        >
+        <div 
+            className="cisvis-data-table-container"
+            style={{ 
+                margin,
+                width: `calc(100% - ${margin * 2}px)`,
+                height: `calc(100% - ${margin * 2}px)`
+            }}>
             <h4 className="chw-table-title">{title}</h4>
             <span style={{ verticalAlign: "middle", display: "inline-block" }}>
                 <svg
@@ -98,7 +99,7 @@ export default function DataTable(props) {
             </span>
             <div
                 style={{
-                    height: height - 40,
+                    height: "calc(100% - 40px)",
                     overflowY: "auto"
                 }}
             >

--- a/src/DataTable.scss
+++ b/src/DataTable.scss
@@ -7,45 +7,49 @@
     height: 100%;
     .cisvis-data-table-container{
         background: white;
+        box-shadow: 0px 0px 30px 0px #444;
         border-radius: 20px;
         padding: 30px;
     }
 }
 
-.chw-table {
+.cisvis-table {
     width: 100%;
     border-collapse: collapse;
     border: none;
     padding-bottom: 10px;
-    tr:nth-child(even) {
-        background: #eeeeee;
+    background: white;
+    thead {
+        border-bottom: 1px solid black;
     }
-    tr:hover {
-        background: #e6f3ff80;
+    tbody tr:hover {
+        background: rgb(233, 233, 233);
     }
     th {
         height: 30px;
-        padding: 0px 4px;
+        padding: 10px 8px;
     }
     tr, td {
-        padding: 0px 4px;
+        padding: 10px 8px;
+        outline: none;
     }
 }
 
-.chw-table-title {
+.cisvis-table-title {
+    font-weight: bold;
     display: inline-block;
+    margin-right: 14px;
 }
 
-.chw-table-subtitle {
+.cisvis-table-subtitle {
     display: inline-block;
     color: gray;
-    margin-left: 15px;
     position: relative;
-
-    .chw-progress-ring {
+    .cisvis-progress-ring {
         display: inline-block;
         left: auto;
-        margin-left: 0px;
+        margin-left: 2px;
+        margin-right: 6px;
         top: 4px;
     }
 }

--- a/src/DataTable.scss
+++ b/src/DataTable.scss
@@ -1,3 +1,17 @@
+.cisvis-data-table-bg { 
+    position: fixed;
+    background: rgba(0, 0, 0, 0.6);
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    .cisvis-data-table-container{
+        background: white;
+        border-radius: 20px;
+        padding: 30px;
+    }
+}
+
 .chw-table {
     width: 100%;
     border-collapse: collapse;

--- a/src/DataTableForIntervalTFs.js
+++ b/src/DataTableForIntervalTFs.js
@@ -6,10 +6,6 @@ import { requestIntervalTFs } from './utils/cistrome.js';
 
 /**
  * Wrapper around <DataTable />, specific for showing the TF binding interval request results.
- * @prop {number} left The left position of this view.
- * @prop {number} top The top position of this view.
- * @prop {number} width The width of this view.
- * @prop {number} height The height of this view.
  * @prop {object} intervalParams The interval request parameters.
  * @prop {string} intervalParams.assembly
  * @prop {string} intervalParams.chrStartName
@@ -19,7 +15,6 @@ import { requestIntervalTFs } from './utils/cistrome.js';
  */
 export default function DataTableForIntervalTFs(props) {
     const {
-        left, top, width, height,
         intervalParams
     } = props;
 
@@ -43,8 +38,32 @@ export default function DataTableForIntervalTFs(props) {
             requestIntervalTFs(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos)
                 .then(([rows, columns]) => {
                     if(didUnmount) return;
-                    setDataTableRows(rows);
-                    setDataTableColumns(columns);
+
+                    // TODO: Consider supporting multiple API queries.
+                    const customColumnMap = {
+                        GSM: "GEO/ENCODE ID",
+                        DCid: "CistromeDB ID",
+                        factor: "Factor",
+                        cellLine: "Cell Line",
+                        CellType: "Cell Type",
+                        species: "Species",
+                        OverlapRatio: "Overlap Ratio",
+                        OverlapPeakNumber: "Overlap Peak Number",
+                    }
+                    const customRows = rows.map(r => {
+                        const newRow = {};
+                        Object.keys(customColumnMap).forEach(k => {
+                            if(customColumnMap[k]) {
+                                newRow[customColumnMap[k]] = r[k];
+                            }
+                        });
+                        return newRow;
+                    });
+                    const costomColumns = Object.values(customColumnMap);
+                    console.log(customRows);
+                    console.log(costomColumns);
+                    setDataTableRows(customRows);
+                    setDataTableColumns(costomColumns);
 
                     const msg = `For interval ${chrStartName}:${chrStartPos}-${chrEndPos}`;
                     setRequestStatus({ msg, isLoading: false });
@@ -62,12 +81,13 @@ export default function DataTableForIntervalTFs(props) {
         <div className="cisvis-data-table-bg">
             <DataTable 
                 margin={100}
-                title={"TFs from Cistrome DB"}
+                title={"Factors from Cistrome DB"}
                 subtitle={requestStatus.msg}
                 isLoading={requestStatus.isLoading}
                 rows={dataTableRows}
                 columns={dataTableColumns}
-                onCheckRows={() => {}}
+                expoNotations={["Overlap Ratio"]}
+                onCheckRows={undefined}
                 onClose={() => setIsVisible(false)}
             />
         </div>

--- a/src/DataTableForIntervalTFs.js
+++ b/src/DataTableForIntervalTFs.js
@@ -60,8 +60,6 @@ export default function DataTableForIntervalTFs(props) {
                         return newRow;
                     });
                     const costomColumns = Object.values(customColumnMap);
-                    console.log(customRows);
-                    console.log(costomColumns);
                     setDataTableRows(customRows);
                     setDataTableColumns(costomColumns);
 

--- a/src/DataTableForIntervalTFs.js
+++ b/src/DataTableForIntervalTFs.js
@@ -56,21 +56,20 @@ export default function DataTableForIntervalTFs(props) {
         }
         setIsVisible(true);
         return (() => { didUnmount = true; });
-    }, [intervalParams]);
+    }, [intervalParams]);    
 
     return (requestStatus && isVisible ? (
-        <DataTable 
-            left={left}
-            top={top}
-            width={width}
-            height={height}
-            title={"TFs from Cistrome DB"}
-            subtitle={requestStatus.msg}
-            isLoading={requestStatus.isLoading}
-            rows={dataTableRows}
-            columns={dataTableColumns}
-            onCheckRows={() => {}}
-            onClose={() => setIsVisible(false)}
-        />
+        <div className="cisvis-data-table-bg">
+            <DataTable 
+                margin={100}
+                title={"TFs from Cistrome DB"}
+                subtitle={requestStatus.msg}
+                isLoading={requestStatus.isLoading}
+                rows={dataTableRows}
+                columns={dataTableColumns}
+                onCheckRows={() => {}}
+                onClose={() => setIsVisible(false)}
+            />
+        </div>
     ) : null);
 }

--- a/src/TrackRowInfoControl.scss
+++ b/src/TrackRowInfoControl.scss
@@ -78,7 +78,7 @@
     background: gray !important;
 }
 
-.chw-progress-ring {
+.cisvis-progress-ring {
     left: calc(50% - 10px);
     position: relative;
     border: 3px solid #f3f3f3;

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -302,7 +302,6 @@ export default function TrackRowInfoVisDendrogram(props) {
                 node = node.parent;
             }
             subtree.reverse();
-            console.log(subtree);
             PubSub.publish(EVENT.CONTEXT_MENU, {
                 x: mouseViewportX,
                 y: mouseViewportY,

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -311,8 +311,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
             <svg ref={axisRef} 
                 style={{ 
                     pointerEvents: "none",
-                    position: "absolute", 
-                    zIndex: 2
+                    position: "absolute"
                 }}
             />
             <TrackRowInfoControl

--- a/src/ViewWrapper.js
+++ b/src/ViewWrapper.js
@@ -231,14 +231,7 @@ export default function ViewWrapper(props) {
                     : null}
                 </div>
             </div>
-            <div
-                style={{
-                    position: "absolute",
-                    top: `${top+height+40}px`,
-                    left: `${left}px`,
-                    width: `${width}px`
-                }}
-            >
+            <div>
                 {requestedIntervalParams ? 
                     <DataTableForIntervalTFs
                         left={0}

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -218,7 +218,7 @@ export default function App() {
         <div className="app">
             <div className="header-container">
                 <div className="header">
-                    <span>Cistrome Explorer</span>
+                    <span className="cisvis-title">Cistrome Explorer</span>
                     <span className="viewconf-options">
                         <select 
                             onChange={e => setSelectedDemo(e.target.value)} 

--- a/src/demo/App.scss
+++ b/src/demo/App.scss
@@ -17,6 +17,9 @@
             text-align: left;
             padding-left: 15px;
             padding-right: 15px;
+            .cisvis-title {
+                color: black;
+            }
             .viewconf-options {
                 margin-left: 10px;
                 font-size: 14px;


### PR DESCRIPTION
I've updated the appearance and formats of the API result table. 

I used custom css without any styling library (e.g., bootstrap) so we can easily change the appearance for example using the "drawer" layout you've mentioned. Here, I used the modal-like layout for showing the table because I thought that the table are currently too wide to use such the drawer layout.

### Updates (Fixes #214)
- [x] Use scientific notations (e.g., "OverlapRatio")
- [x] Use more readable formats of titles by not using the 'raw' variable names
   - e.g., "OverlapPeakNumber" => "Overlap Peak Number"
- [x] Use consistent capitalization (e.g., "factor" vs. "Overlap ...")
- [x] Reorder columns based on the field types and importance of values (e.g., we can refer to Cistrome Website for the column order, http://cistrome.org/db/#/).
- [x] Remove the columns that are less likely to be interested by users 
   - e.g., "DCid"

<img width="1647" alt="Screen Shot 2020-05-27 at 4 42 40 PM" src="https://user-images.githubusercontent.com/9922882/83071112-95ccdd80-a03a-11ea-9197-dad34c319679.png">
