### PR TITLE
Fix z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.4.0 - in progress
+## 0.5.0 - in progress
+
+## 0.4.0
 
 ### Added
 - Added row aggregation options (e.g., `rowAggregate`) to aggregate rows based on nominal fields metadata.
@@ -10,6 +12,8 @@
 - Filtering information in range sliders and keyword search boxes is based on the aggregated values (`aggregatedRowInfo`), instead of original `rowInfo`.
 - Fixed a SVG export bug which caused visualizations to be exported from previous datasets (corresponding to previous `options` prop values in the demo).
 - Updaetd a Cistrome DB Toolkit view to show two APIs with the history of request and data tables of each request.
+- Fixed z-index between track resizer, filtering box, and toolkit.
+- Rename the keyword search box (`TrackRowSearch` => `TrackRowFilter`).
 
 ## 0.3.0 - 05/27/20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cistrome-explorer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Gehlenborg Lab (http://gehlenborglab.org/)",
   "license": "MIT",
   "repository": {

--- a/src/CistromeToolkit.scss
+++ b/src/CistromeToolkit.scss
@@ -2,11 +2,12 @@
     transition: height 0.2s ease-out;
 }
 .cisvis-data-table-bg-no-transition,
-.cisvis-data-table-bg { 
+.cisvis-data-table-bg {
     position: fixed;
     left: 0;
     bottom: 0;
     width: 100%;
+    z-index: 3;
     .cisvis-data-table-header {
         height: 3px;
         background: #666;

--- a/src/TrackRowFilter.js
+++ b/src/TrackRowFilter.js
@@ -2,29 +2,29 @@ import React, { useRef, useState, useEffect, useCallback, useMemo } from "react"
 import { CLOSE, FILTER, RESET, SEARCH, SQUARE_CHECK, SQUARE } from './utils/icons.js';
 import d3 from "./utils/d3.js";
 
-import './TrackRowSearch.scss';
+import './TrackRowFilter.scss';
 import RangeSlider from "./RangeSlider.js";
 import { getAggregatedValue } from "./utils/aggregate.js";
 
 const MAX_NUM_SUGGESTIONS = 200;
 
 /**
- * Text field to serach for keywords.
+ * Component to help determining rows to filter.
  * @prop {boolean} isLeft Is this view on the left side of the HiGlass track?
  * @prop {number} top The top coordinate.
  * @prop {number} left The left coordinate.
  * @prop {string} field The name of field related to the wrapper track.
  * @prop {string} type The type of field related to the wrapper track.
  * @prop {string} aggFunction The function to apply upon row aggregation.
- * @prop {function} onChange The function to call when the search keyword has changed.
+ * @prop {function} onChange The function to call when the search keyword or value range has changed.
  * @prop {function} onFilterRows The function to call when the filter should be applied.
- * @prop {function} onClose The function to call when the search field should be closed.
+ * @prop {function} onClose The function to call when filter component should be closed.
  * @prop {object[]} rowInfo The array of JSON Object containing row information.
  * @prop {object} filterInfo The options for filtering rows of the field used in this track.
  * @example
- * <TrackRowSearch/>
+ * <TrackRowFilter/>
  */
-export default function TrackRowSearch(props) {
+export default function TrackRowFilter(props) {
 
     const {
         isLeft,
@@ -156,7 +156,7 @@ export default function TrackRowSearch(props) {
         setKeyword("");
     }
 
-    function onSearchClose() {
+    function onFilterClose() {
         onChange("");
         onClose();
         setKeyword("");
@@ -236,7 +236,7 @@ export default function TrackRowSearch(props) {
                 break;
             case 'Esc':
             case 'Escape':
-                onSearchClose(); 
+                onFilterClose(); 
                 break;
         }
     }
@@ -287,14 +287,14 @@ export default function TrackRowSearch(props) {
 
     return (
         <div
-            className="chw-search"
+            className="chw-filter"
             style={{
                 display: ((left !== null && top !== null) ? 'flex' : 'none'),
                 left: left - (width + padding * 2) / 2 + offset.x,
                 top: top - (height + padding * 2) - 80 + offset.y,
             }}
         >
-            <div className="chw-search-box"
+            <div className="chw-filter-box"
                 style={{
                     padding: padding,
                     paddingLeft: '0px'
@@ -313,7 +313,7 @@ export default function TrackRowSearch(props) {
                 {type === "nominal" || type === "link" ?
                     <input
                         ref={keywordInputRef}
-                        className="chw-search-box-input"
+                        className="chw-filter-box-input"
                         type="text"
                         name="default name"
                         placeholder="Search"
@@ -330,7 +330,7 @@ export default function TrackRowSearch(props) {
                         valueExtent={valueExtent}
                         onChange={onRangeChange}
                         onFilter={onFilterByRange}
-                        onClose={onSearchClose}
+                        onClose={onFilterClose}
                     />
                 }
                 {type === "quantitative" ?
@@ -355,14 +355,14 @@ export default function TrackRowSearch(props) {
                     : null
                 }
                 <svg className="chw-button-sm"
-                    onClick={onSearchClose} viewBox={CLOSE.viewBox}>
-                    <title>Close search box</title>
+                    onClick={onFilterClose} viewBox={CLOSE.viewBox}>
+                    <title>Close filter component</title>
                     <path d={CLOSE.path} fill="currentColor"/>
                 </svg>
             </div>   
             {type === "nominal" || type === "link" ?
                 <div 
-                    className="chw-search-suggestions"
+                    className="chw-filter-suggestions"
                     style={{
                         top: (padding + height),
                         left: "45px",
@@ -376,7 +376,7 @@ export default function TrackRowSearch(props) {
                         {suggestions.map((d, i) => (
                             <li
                                 key={d}
-                                className={"chw-search-suggestion-text " + (i === suggestionIndex ? "active-suggestion" : "")}
+                                className={"chw-filter-suggestion-text " + (i === suggestionIndex ? "active-suggestion" : "")}
                                 onClick={() => onSuggestionEnter(d)}
                                 onMouseEnter={() => setSuggestionIndex(i)}
                                 onMouseLeave={() => setSuggestionIndex(undefined)}

--- a/src/TrackRowFilter.scss
+++ b/src/TrackRowFilter.scss
@@ -1,26 +1,26 @@
-.chw-search {
+.chw-filter {
     position: absolute;
-    z-index: 1;
+    z-index: 2;
     flex-direction: column;
     border-radius: 6px;
     background: white;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 3px 0 rgba(0, 0, 0, 0.075), 0 0 7px 0 rgba(0, 0, 0, 0.05);
     opacity: 0.8;
-    .chw-search-box {
+    .chw-filter-box {
         width: auto;
         height: auto;
         display: flex;
         align-items: center;
-        .chw-search-box-input {
+        .chw-filter-box-input {
             margin-right: 6px;
             border: none;
             border-bottom: solid 1px lightgray;
         }
-        .chw-search-box-input:focus{
+        .chw-filter-box-input:focus{
             outline: none;
         }
     }
-    .chw-search-suggestions {
+    .chw-filter-suggestions {
         line-height: 14px;
         border-left: 1px solid silver;
         border-right: 1px solid silver;
@@ -37,15 +37,15 @@
         }
     }
 }
-.chw-search:hover,
-.chw-search:focus-within {
+.chw-filter:hover,
+.chw-filter:focus-within {
     opacity: 1;
 }
 
-.chw-search-suggestion-text {
+.chw-filter-suggestion-text {
     cursor: pointer;
 }
 
-.chw-search-suggestion-text.active-suggestion {
+.chw-filter-suggestion-text.active-suggestion {
     background: rgb(225, 225, 225);
 }

--- a/src/TrackRowInfoControl.js
+++ b/src/TrackRowInfoControl.js
@@ -2,7 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import PubSub from 'pubsub-js';
 
 import { SORT_ASC, SORT_DESC, FILTER, RESET, TOGGLE_ON } from './utils/icons.js';
-import TrackRowSearch from './TrackRowSearch.js';
+import TrackRowFilter from './TrackRowFilter.js';
 import { getAggregatedValue } from './utils/aggregate.js';
 
 const LOCAL_EVENT_SEARCH_OPEN = "search-open";
@@ -168,7 +168,7 @@ export default function TrackRowInfoControl(props){
                 })}
             </div>
             {isSearching ? (
-                <TrackRowSearch
+                <TrackRowFilter
                     isLeft={isLeft}
                     top={searchTop}
                     left={searchLeft}


### PR DESCRIPTION
Fix z-index between track resizers, filtering components, and a toolkit view: Resizers are placed under filtering components, and the filtering components are placed under the toolkit view.

I also renamed `TrackRowSearch` => `TrackRowFilter` for the clarity.

**Before:**
![before](https://user-images.githubusercontent.com/9922882/86194009-6159af00-bb1b-11ea-8069-75ed42d3e281.png)

**After:**
![after](https://user-images.githubusercontent.com/9922882/86194012-64549f80-bb1b-11ea-8b22-c2d8ca46e52e.png)