### PR TITLE
Revert to higlass v1.10.1 due to workerSetPix bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vega-scale": "^6.0.0"
   },
   "peerDependencies": {
-    "higlass": "^1.10.2",
+    "higlass": "1.10.1",
     "pixi.js": "^5.0.3",
     "react": "^16.12.0",
     "react-bootstrap": "0.32.1",

--- a/rollup.demo.utils.js
+++ b/rollup.demo.utils.js
@@ -1,4 +1,4 @@
-const hgVersion = '1.10.2';
+const hgVersion = '1.10.1';
 const peerScripts = {
     'development': `
         <script crossorigin type="text/javascript" src="https://unpkg.com/react@16/umd/react.development.js"></script>


### PR DESCRIPTION
I think I introduced a bug in the workerSetPix function in higlass, so this reverts to the previous version while I work on fixing that.