### PR TITLE
Fix highlighting on dendrograms

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -27,6 +27,7 @@ toc:
 - ViewColumnBrush
 - SuggestionWithHighlight
 - name: Functions (internal)
+- getConditionFromHighlightOption
 - getHighlightKeyByFieldType
 - addTrackWrapperOptions
 - validateWrapperOptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Moved `CistromeToolkit` to the sibling of `CistromeHGW`.
 - Rename `HiGlassWithMeta` to `HiGlassMeta`.
 - Upgraded to HiGlass version `1.10.2`
+- Fix the bug on highlighting rows in dendrograms.
 
 ## 0.4.0
 

--- a/src/HiGlassMetaConsumer.js
+++ b/src/HiGlassMetaConsumer.js
@@ -20,7 +20,8 @@ import {
     getWrapperSubOptions,
     updateWrapperOptions,
     addTrackWrapperOptions,
-    getHighlightKeyByFieldType
+    getHighlightKeyByFieldType,
+    getConditionFromHighlightOption
 } from './utils/options.js';
 import { 
     getHMTrackIdsFromViewConfig, 
@@ -137,8 +138,7 @@ const HiGlassMetaConsumer = forwardRef((props, ref) => {
         let newHighlitRows = undefined; // `undefined` resets the hightlighting
         if(trackOptions.rowHighlight) {
             const { field, type } = trackOptions.rowHighlight;
-            const highlightKey = getHighlightKeyByFieldType(type, condition);
-            const condition = trackOptions.rowHighlight[highlightKey];
+            const condition = getConditionFromHighlightOption(trackOptions.rowHighlight);
             newHighlitRows = highlightRowsFromSearch(rowInfo, field, type, condition, trackOptions);
         }
         if(!isEqual(newHighlitRows, context.state[viewId][trackId].highlitRows)) {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -229,17 +229,39 @@ const optionsObjectSchema = merge(cloneDeep(baseSchema), {
 });
 
 /**
+ * Return a condition for highlighting rows (e.g., `subtree` for dendrogram tracks).
+ * @param {Object} highlitOption A `rowHighlight` object.
+ * @returns {string|array|null} The condition for highlighting rows for a given field type. `null` if no proper condition found.
+ */
+export function getConditionFromHighlightOption(highlitOption) {
+    const { type } = highlitOption;
+    const key = Object.keys(highlitOption).find(k => 
+        k !== "field" && 
+        k !== "type" &&
+        k === getHighlightKeyByFieldType(type, highlitOption[k]) // key should match with the given field type
+    );
+    if(!key) {
+        console.warn("No proper condition for a given field type is provided in the following options:", highlitOption);
+    }
+    return key ? highlitOption[key] : null;
+}
+
+/**
  * Get a key in `rowHighlight` object that indicate a certain condition (e.g., `contains`) for highlighting.
  * @param {string} type The field type.
+ * @param {string} condition The condition in options for applying highlighting.
  * @returns {string} The key of `rowHighlight` object that indicate a certain condition.
  */
-export function getHighlightKeyByFieldType(type, condition) {
+export function getHighlightKeyByFieldType(type, condition = undefined) {
   switch(type) {
     case "quantitative":
         return "range";
     case "nominal":
         return "contains";
     case "tree":
+        if(!condition) {
+            console.warn("`condition` is not properly provided, so we are just guessing a HighlightKey");
+        }
         return Array.isArray(condition) ? "subtree" : "minSimilarity";
   }
 }


### PR DESCRIPTION
Fixes #294 

The problem was mainly based on my mistake from a previous PR, where I used a not-defined local variable, `condition`, in src/HiGlassMetaConsumer.js.

@keller-mark Should we add an es-lint configuration to avoid such bugs?