### PR TITLE
Run pipeline

### DIFF
--- a/pipelines/cistrome-to-multivec/.gitignore
+++ b/pipelines/cistrome-to-multivec/.gitignore
@@ -10,4 +10,5 @@ __pycache__/
 *.bw
 *.json
 *.out
+*.err
 data/

--- a/pipelines/cistrome-to-multivec/.gitignore
+++ b/pipelines/cistrome-to-multivec/.gitignore
@@ -9,4 +9,5 @@ __pycache__/
 *.bed
 *.bw
 *.json
+*.out
 data/

--- a/pipelines/cistrome-to-multivec/README.md
+++ b/pipelines/cistrome-to-multivec/README.md
@@ -24,7 +24,16 @@ conda env create -f environment.yml
 conda activate cistrome-to-multivec-pipeline
 ```
 
+## Snakemake cluster config
+
+```sh
+mkdir -p ~/.config/snakemake/cistrome-explorer
+cp ./cluster-profile.yml ~/.config/snakemake/cistrome-explorer/config.yml
+```
+
 ## Using parallel hdf5 via h5py and mpi4py
+
+*The following info is outdated, since h5py does not yet work with the parallel version of hdf5 installed on the o2 cluster. In the meantime we can do parallelization by submitting many simultaneous snakemake jobs for each output bigwig file.*
 
 https://docs.h5py.org/en/latest/build.html#building-against-parallel-hdf5
 

--- a/pipelines/cistrome-to-multivec/README.md
+++ b/pipelines/cistrome-to-multivec/README.md
@@ -13,23 +13,23 @@ snakemake --cores 2 --config filetype=zarr
 ./submit.sh mv5 my_username
 ```
 
-# Setup
+## Setup
 
-## Conda environment
+### Create conda environment
 
 ```sh
 conda env create -f environment.yml
 conda activate cistrome-to-multivec-pipeline
 ```
 
-## Snakemake cluster config
+### Copy snakemake cluster config
 
 ```sh
 mkdir -p ~/.config/snakemake/cistrome-explorer
 cp ./cluster-profile.yml ~/.config/snakemake/cistrome-explorer/config.yaml
 ```
 
-# Sync output files with s3 bucket
+### Sync output files with s3 bucket
 
 ```sh
 # replace with your credentials
@@ -43,13 +43,13 @@ aws s3 sync /n/scratch3/users/m/mk596/cistrome-explorer/data/processed/ s3://hig
 ```
 
 
-## Using parallel hdf5 via h5py and mpi4py
+### Using parallel hdf5 via h5py and mpi4py
 
 *The following info is outdated, since h5py does not yet work with the parallel version of hdf5 installed on the o2 cluster. In the meantime we can do parallelization by submitting many simultaneous snakemake jobs for each output bigwig file.*
 
 https://docs.h5py.org/en/latest/build.html#building-against-parallel-hdf5
 
-### On O2
+#### On O2
 
 ```sh
 module load gcc/6.2.0
@@ -71,7 +71,7 @@ python setup.py configure --mpi
 python setup.py install
 ```
 
-### On macOS
+#### On macOS
 
 Download hdf5 1.10.6 source code from https://www.hdfgroup.org/downloads/hdf5/source-code/ and un-tar-gz
 

--- a/pipelines/cistrome-to-multivec/README.md
+++ b/pipelines/cistrome-to-multivec/README.md
@@ -9,7 +9,7 @@ conda activate cistrome-to-multivec-pipeline
 snakemake --cores 2 --config filetype=mv5
 # or, to generate zarr outputs
 snakemake --cores 2 --config filetype=zarr
-# or, if on O2 (replace with your username)
+# or, if on O2 (replace with your O2 username)
 ./submit.sh mv5 my_username
 ```
 
@@ -27,6 +27,19 @@ conda activate cistrome-to-multivec-pipeline
 ```sh
 mkdir -p ~/.config/snakemake/cistrome-explorer
 cp ./cluster-profile.yml ~/.config/snakemake/cistrome-explorer/config.yaml
+```
+
+# Sync output files with s3 bucket
+
+```sh
+# replace with your credentials
+export AWS_ACCESS_KEY_ID="{my_access_key_id}"
+export AWS_SECRET_ACCESS_KEY="{my_secret_access_key}"
+export AWS_DEFAULT_REGION="us-east-1"
+
+# replace with your O2 username details
+# .../users/{first_letter_of_username}/{username}/cistrome-explorer/...
+aws s3 sync /n/scratch3/users/m/mk596/cistrome-explorer/data/processed/ s3://higlass-server/
 ```
 
 

--- a/pipelines/cistrome-to-multivec/README.md
+++ b/pipelines/cistrome-to-multivec/README.md
@@ -1,18 +1,16 @@
 
-Generate multivec files from CistromeDB bigWig files:
+# pipelines/cistrome-to-multivec
+
+Generate multivec files from CistromeDB bigWig files.
+
 ```sh
 conda activate cistrome-to-multivec-pipeline
+# to generate multivec outputs
 snakemake --cores 2 --config filetype=mv5
-# or
+# or, to generate zarr outputs
 snakemake --cores 2 --config filetype=zarr
-# or, if on O2
-snakemake --cores 2 --config filetype=mv5 user={your_o2_username}
-```
-
-Ingest the processed multivec files with `higlass-server`:
-```sh
-conda activate higlass-server
-bash higlass_ingest.sh path/to/higlass-server # fill in this path
+# or, if on O2 (replace with your username)
+./submit.sh mv5 my_username
 ```
 
 # Setup
@@ -28,8 +26,9 @@ conda activate cistrome-to-multivec-pipeline
 
 ```sh
 mkdir -p ~/.config/snakemake/cistrome-explorer
-cp ./cluster-profile.yml ~/.config/snakemake/cistrome-explorer/config.yml
+cp ./cluster-profile.yml ~/.config/snakemake/cistrome-explorer/config.yaml
 ```
+
 
 ## Using parallel hdf5 via h5py and mpi4py
 

--- a/pipelines/cistrome-to-multivec/README.md
+++ b/pipelines/cistrome-to-multivec/README.md
@@ -39,7 +39,7 @@ export AWS_DEFAULT_REGION="us-east-1"
 
 # replace with your O2 username details
 # .../users/{first_letter_of_username}/{username}/cistrome-explorer/...
-aws s3 sync /n/scratch3/users/m/mk596/cistrome-explorer/data/processed/ s3://higlass-server/
+aws s3 sync /n/scratch3/users/m/mk596/cistrome-explorer/data/processed/ s3://higlass-server/CistromeDB/
 ```
 
 

--- a/pipelines/cistrome-to-multivec/Snakefile
+++ b/pipelines/cistrome-to-multivec/Snakefile
@@ -26,7 +26,7 @@ SAMPLE_METADATA_URL = "http://dc2.cistrome.org/api/inspector?id={cid}"
 
 # Process the config
 #GROUP_NAMES = config["groups"].keys() # TODO: uncomment
-GROUP_NAMES = [ name for name, group in config["groups"].items() if len(group) < 100 and name[0] == "H" ][0:250]
+GROUP_NAMES = [ name for name, group in config["groups"].items() if len(group) < 100 and name[0] == "H" ]
 
 FILETYPE = config.get("filetype", "mv5")
 OUTFILE_WRAPPER = directory if FILETYPE == "zarr" else (lambda x: x)

--- a/pipelines/cistrome-to-multivec/Snakefile
+++ b/pipelines/cistrome-to-multivec/Snakefile
@@ -26,7 +26,7 @@ SAMPLE_METADATA_URL = "http://dc2.cistrome.org/api/inspector?id={cid}"
 
 # Process the config
 #GROUP_NAMES = config["groups"].keys() # TODO: uncomment
-GROUP_NAMES = [ name for name, group in config["groups"].items() if len(group) < 100 and name[0] == "H" ]
+GROUP_NAMES = [ name for name, group in config["groups"].items() if len(group) < 100 and name[0] == "H" ][:300]
 
 FILETYPE = config.get("filetype", "mv5")
 OUTFILE_WRAPPER = directory if FILETYPE == "zarr" else (lambda x: x)

--- a/pipelines/cistrome-to-multivec/Snakefile
+++ b/pipelines/cistrome-to-multivec/Snakefile
@@ -26,7 +26,7 @@ SAMPLE_METADATA_URL = "http://dc2.cistrome.org/api/inspector?id={cid}"
 
 # Process the config
 #GROUP_NAMES = config["groups"].keys() # TODO: uncomment
-GROUP_NAMES = ['Homo_sapiens__BTAF1__all', 'Homo_sapiens__PHF8__all', 'Homo_sapiens__SMAD3__all', 'Homo_sapiens__H3K27ac__all']
+GROUP_NAMES = [ name for name, group in config["groups"].items() if len(group) < 100 and name[0] == "H" ][0:250]
 
 FILETYPE = config.get("filetype", "mv5")
 OUTFILE_WRAPPER = directory if FILETYPE == "zarr" else (lambda x: x)
@@ -37,6 +37,7 @@ rule all:
         expand(join(PROCESSED_DIR, f"{{group_name}}.multires.{FILETYPE}"), group_name=GROUP_NAMES),
 
 rule manifest_to_outfile:
+    group: "outfile_group"
     input:
         bigwigs=lambda w: expand(join(RAW_DIR, "{cid}.bw"), cid=config["groups"][w.group_name]),
         metadata=lambda w: expand(join(RAW_DIR, "{cid}.metadata.json"), cid=config["groups"][w.group_name]),
@@ -45,7 +46,9 @@ rule manifest_to_outfile:
         OUTFILE_WRAPPER(join(PROCESSED_DIR, f"{{group_name}}.multires.{FILETYPE}"))
     params:
         starting_resolution=1000,
-        script=join(SRC_DIR, f"manifest_to_{FILETYPE}.py")
+        script=join(SRC_DIR, f"manifest_to_{FILETYPE}.py"),
+        rm_input_bigwigs=False
+        # TODO: implement rm_input_bigwigs=True in the python script
     shell:
         """
         python {params.script} \
@@ -55,6 +58,7 @@ rule manifest_to_outfile:
         """
 
 rule bigwigs_to_manifest:
+    group: "outfile_group"
     input:
         bigwigs=lambda w: expand(join(RAW_DIR, "{cid}.bw"), cid=config["groups"][w.group_name]),
         metadata=lambda w: expand(join(RAW_DIR, "{cid}.metadata.json"), cid=config["groups"][w.group_name]),
@@ -64,6 +68,7 @@ rule bigwigs_to_manifest:
         join(SRC_DIR, "bigwigs_to_manifest.py")
 
 rule download_bigwig:
+    group: "outfile_group"
     input:
         join(RAW_DIR, "{cid}.data.json")
     output:
@@ -74,6 +79,7 @@ rule download_bigwig:
         '''
 
 rule download_bigwig_metadata:
+    group: "outfile_group"
     output:
         metadata_json=join(RAW_DIR, "{cid}.metadata.json"),
         data_json=join(RAW_DIR, "{cid}.data.json")

--- a/pipelines/cistrome-to-multivec/Snakefile
+++ b/pipelines/cistrome-to-multivec/Snakefile
@@ -45,7 +45,7 @@ rule manifest_to_outfile:
     output:
         OUTFILE_WRAPPER(join(PROCESSED_DIR, f"{{group_name}}.multires.{FILETYPE}"))
     params:
-        starting_resolution=1000,
+        starting_resolution=200,
         script=join(SRC_DIR, f"manifest_to_{FILETYPE}.py"),
         rm_input_bigwigs=False
         # TODO: implement rm_input_bigwigs=True in the python script

--- a/pipelines/cistrome-to-multivec/cluster-profile.yml
+++ b/pipelines/cistrome-to-multivec/cluster-profile.yml
@@ -1,3 +1,3 @@
-cluster: 'sbatch -p medium -n 4 -t 1-00:00:00 --mem=8000'
+cluster: 'sbatch -p medium -n 1 -t 1-00:00:00 --mem=8000'
 jobs: 100
 latency-wait: 60

--- a/pipelines/cistrome-to-multivec/cluster-profile.yml
+++ b/pipelines/cistrome-to-multivec/cluster-profile.yml
@@ -1,3 +1,3 @@
-cluster: 'sbatch -p medium -n 1 -t 1-00:00:00 --mem=8000'
+cluster: 'sbatch -p medium -n 4 -t 1-00:00:00 --mem=8000'
 jobs: 100
 latency-wait: 60

--- a/pipelines/cistrome-to-multivec/cluster-profile.yml
+++ b/pipelines/cistrome-to-multivec/cluster-profile.yml
@@ -1,0 +1,3 @@
+cluster: 'sbatch -p medium -n 1 -t 1-00:00:00 --mem=8000'
+jobs: 100
+latency-wait: 60

--- a/pipelines/cistrome-to-multivec/src/manifest_to_mv5.py
+++ b/pipelines/cistrome-to-multivec/src/manifest_to_mv5.py
@@ -90,7 +90,12 @@ def bigwigs_to_multivec(
     row_infos = []
     for metadata_index, metadata_file in enumerate(input_metadata_files):
         with open(metadata_file) as mf:
-            metadata_json = json.load(mf)
+            try:
+                metadata_json = json.load(mf)
+            except Exception as e:
+                print(f"Error loading metadata file: {metadata_file}")
+                print(e)
+                metadata_json = None
         row_info = metadata_json_to_row_info(metadata_json)
         row_infos.append(row_info)
     

--- a/pipelines/cistrome-to-multivec/src/manifest_to_mv5.py
+++ b/pipelines/cistrome-to-multivec/src/manifest_to_mv5.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Create a multivec file.')
     parser.add_argument('-i', '--input', type=str, required=True, help='The input manifest JSON file.')
     parser.add_argument('-o', '--output', type=str, required=True, help='The output multivec file.')
-    parser.add_argument('-s', '--starting-resolution', type=int, default=1000, help='The starting resolution.')
+    parser.add_argument('-s', '--starting-resolution', type=int, default=200, help='The starting resolution.')
     args = parser.parse_args()
 
     with open(args.input) as f:

--- a/pipelines/cistrome-to-multivec/src/utils.py
+++ b/pipelines/cistrome-to-multivec/src/utils.py
@@ -28,6 +28,8 @@ def metadata_json_to_row_info(metadata_json):
             return None
         except IndexError:
             return None
+        except TypeError:
+            return None
         return None
 
     # Flatten the metadata object

--- a/pipelines/cistrome-to-multivec/submit.sh
+++ b/pipelines/cistrome-to-multivec/submit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH -c 4 # number of cores
+#SBATCH -c 1 # number of cores
 #SBATCH -N 1 # number of nodes
 #SBATCH -t 1-00:00 # runtime in D-HH:MM format
 #SBATCH -p medium # partition

--- a/pipelines/cistrome-to-multivec/submit.sh
+++ b/pipelines/cistrome-to-multivec/submit.sh
@@ -10,4 +10,4 @@
 source ~/.bashrc_mark # to load the `conda activate` command
 
 conda activate cistrome-to-multivec-pipeline
-snakemake --profile cistrome-explorer --local-cores 4 --keep-going --config filetype=$1 user=$2
+snakemake --profile cistrome-explorer --keep-going --config filetype=$1 user=$2

--- a/pipelines/cistrome-to-multivec/submit.sh
+++ b/pipelines/cistrome-to-multivec/submit.sh
@@ -4,9 +4,8 @@
 #SBATCH -t 1-00:00 # runtime in D-HH:MM format
 #SBATCH -p medium # partition
 #SBATCH --mem=2000 # memory in MB (for all cores)
-#SBATCH -o hostname_%j.out # file for STDOUT with job ID
-#SBATCH -e hostname_%j.err # file for STDERR with job ID
+#SBATCH -o snakemake-%j.out # file for STDOUT with job ID
+#SBATCH -e snakemake-%j.err # file for STDERR with job ID
 
-source ~/.bashrc_mark
 conda activate cistrome-to-multivec-pipeline
-snakemake --profile cistrome-explorer --config filetype=mv5 user=mk596
+snakemake --profile cistrome-explorer --config filetype=$1 user=$2

--- a/pipelines/cistrome-to-multivec/submit.sh
+++ b/pipelines/cistrome-to-multivec/submit.sh
@@ -7,5 +7,7 @@
 #SBATCH -o snakemake-%j.out # file for STDOUT with job ID
 #SBATCH -e snakemake-%j.err # file for STDERR with job ID
 
+source ~/.bashrc_mark # to load the `conda activate` command
+
 conda activate cistrome-to-multivec-pipeline
 snakemake --profile cistrome-explorer --local-cores 4 --keep-going --config filetype=$1 user=$2

--- a/pipelines/cistrome-to-multivec/submit.sh
+++ b/pipelines/cistrome-to-multivec/submit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH -c 1 # number of cores
+#SBATCH -c 4 # number of cores
 #SBATCH -N 1 # number of nodes
 #SBATCH -t 1-00:00 # runtime in D-HH:MM format
 #SBATCH -p medium # partition
@@ -8,4 +8,4 @@
 #SBATCH -e snakemake-%j.err # file for STDERR with job ID
 
 conda activate cistrome-to-multivec-pipeline
-snakemake --profile cistrome-explorer --config filetype=$1 user=$2
+snakemake --profile cistrome-explorer --local-cores 4 --keep-going --config filetype=$1 user=$2

--- a/pipelines/cistrome-to-multivec/submit.sh
+++ b/pipelines/cistrome-to-multivec/submit.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH -c 1 # number of cores
+#SBATCH -N 1 # number of nodes
+#SBATCH -t 1-00:00 # runtime in D-HH:MM format
+#SBATCH -p medium # partition
+#SBATCH --mem=2000 # memory in MB (for all cores)
+#SBATCH -o hostname_%j.out # file for STDOUT with job ID
+#SBATCH -e hostname_%j.err # file for STDERR with job ID
+
+source ~/.bashrc_mark
+conda activate cistrome-to-multivec-pipeline
+snakemake --profile cistrome-explorer --config filetype=mv5 user=mk596


### PR DESCRIPTION
Minor changes to the snakemake pipeline
- use snakemake "groups" to execute multiple related rules in the same cluster node to reduce overhead of submitting many separate slurm jobs
- add a bash script `submit.sh`
- update the partial list of files to process (but limit to 300 to prevent processing all files)
- add an s3 sync command to readme
- update the base resolution to 200