### PR TITLE
Rename `subtree` to `ancestors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,26 @@
 - Undo/Redu interactions added in Cistrome Explorer.
 - Added an `onOptions` API in `HiGlassMeta` to change the wrapper options outside the library.
 - Added a menu panel that shows examples datasets and any other high-level options for `HiGlassMeta`.
+- Added linking tracks with background color upon mouse hover.
+- Added `resolveYScale` and `sort` options for using track-specific Y-axis scale.
+- Added line/band connections between tracks whey they use different y-axis scales.
+- Added `width` options that set the initial size of vertical tracks along x-axis.
+- Added an `onRemoveAllSort` API in `HiGlassMeta` for removing all sort options outside of the library.
 
 ### Changed
 - Moved `CistromeToolkit` to the sibling of `CistromeHGW`.
 - Rename `HiGlassWithMeta` to `HiGlassMeta`.
 - Upgraded to HiGlass version `1.10.2`
 - Fix the bug on highlighting rows in dendrograms.
+- Hide track titles upon mouse hover for addressing visual overlap.
+- Changed the row highlighting method, from reverse highlighting to regular highlighting, i.e., highlight the selected rows.
+- Renamed `subtree` to `ancestors` for clarity.
 
 ## 0.4.0
 
 ### Added
 - Added row aggregation options (e.g., `rowAggregate`) to aggregate rows based on nominal fields metadata.
 - Added visual indicators (vertical black bars) to show which rows are aggregated.
-- Added linking tracks with background color upon mouse hover.
-- Added `resolveYScale` and `sort` options for using track-specific Y-axis scale.
-- Added line/band connections between tracks whey they use different y-axis scales.
-- Added `width` options that set the initial size of vertical tracks along x-axis.
-- Added an `onRemoveAllSort` API in `HiGlassMeta` for removing all sort options outside of the library.
 
 ### Changed
 - Changed the table view to be shown as a modal view.
@@ -30,8 +33,6 @@
 - Updaetd a Cistrome DB Toolkit view to show two APIs with the history of request and data tables of each request.
 - Fixed z-index between track resizer, filtering box, and toolkit.
 - Rename the keyword search box (`TrackRowSearch` => `TrackRowFilter`).
-- Hide track titles upon mouse hover for addressing visual overlap.
-- Changed the row highlighting method, from reverse highlighting to regular highlighting, i.e., highlight the selected rows.
 
 ## 0.3.0 - 05/27/20
 

--- a/src/HiGlassMetaConsumer.js
+++ b/src/HiGlassMetaConsumer.js
@@ -334,7 +334,7 @@ const HiGlassMetaConsumer = forwardRef((props, ref) => {
                 });
                 newSubOptions[fieldOptionIndex] = fieldOption;
             } else if(type === "quantitative" || type === "tree") {
-                // Simply remove `range` or `subtree` and `minSimilarity` filters from the cetain field.
+                // Simply remove `range` or `ancestors` and `minSimilarity` filters from the cetain field.
                 newSubOptions = removeItemFromArray(newSubOptions, newSubOptions.indexOf(fieldOption));
             }
         } else {
@@ -365,11 +365,11 @@ const HiGlassMetaConsumer = forwardRef((props, ref) => {
                 }
             } else if(type === "tree") {
                 // Replace with the incoming.
-                const key = Array.isArray(condition) ? "subtree" : "minSimilarity";
+                const key = Array.isArray(condition) ? "ancestors" : "minSimilarity";
                 if(fieldOption) {
                     const fieldOptionIndex = newSubOptions.indexOf(fieldOption);
                     newSubOptions = modifyItemInArray(newSubOptions, fieldOptionIndex, {
-                        ...fieldOption, [key]: condition // We do not want to remove a `subtree` or `minSimilarity` option if exists.
+                        ...fieldOption, [key]: condition // We do not want to remove a `ancestors` or `minSimilarity` option if exists.
                     });
                 } else {
                     newSubOptions = insertItemToArray(newSubOptions, 0, { field, type, [key]: condition });

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -160,7 +160,7 @@ export default function TrackRowInfoVisDendrogram(props) {
             maxDistance * (newLeft / visWidth);
         setMinSimBarLeft(newLeft);
         
-        // TODO: We want to uncomment the below line, but that is somehow removing `subtree` in `filterInfo`.
+        // TODO: We want to uncomment the below line, but that is somehow removing `ancestors` in `filterInfo`.
         // onHighlightRows(field, "tree", minSimilarity.current);
     }, [maxDistance, width, dragX, minSimBarLeft]);
 

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -73,7 +73,7 @@ export default function TrackWrapper(props) {
         if(["meeting-2020-04-29-track"].includes(multivecTrackTrackId)) {
             // TODO: use the below line to use the real metadata coming from the HiGlass Server tileset_info.
             //       see https://github.com/hms-dbmi/cistrome-explorer/issues/26
-            rowInfo = multivecTrack.tilesetInfo.row_infos.map(JSON.parse);
+            rowInfo = multivecTrack.tilesetInfo.row_infos.map(d => (typeof d === "string" ? JSON.parse(d) : d));
         } else {
             // TODO: remove this else clause.
             //       see https://github.com/hms-dbmi/cistrome-explorer/issues/26

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -220,7 +220,7 @@ export const demos = {
             rowFilter: [ ]
         }
     },
-    "Minimal Dataset (w/ Dendrogram and Aggregation)": {
+    "Minimal Dataset (w/ Similarity Dendrogram)": {
         viewConfig: hgDemoViewConfig2b,
         options: {
             rowInfoAttributes: [
@@ -233,7 +233,8 @@ export const demos = {
             ],
             rowFilter: [ ],
             rowAggregate: [
-                {field: "Tissue Type", type: "nominal", oneOf: ["Blood", "Bone Marrow"]}
+                // Use this for debuging aggregation features
+                // {field: "Tissue Type", type: "nominal", oneOf: ["Blood", "Bone Marrow"]}
             ]
         }
     }

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -39,7 +39,7 @@ const baseSchema = {
                         { "required": ["field", "type", "index"] },
                         { "required": ["field", "type", "contains"] },
                         { "required": ["field", "type", "range"] },
-                        { "required": ["field", "type", "subtree"] },
+                        { "required": ["field", "type", "ancestors"] },
                         { "required": ["field", "type", "minSimilarity"] },
                     ],
                     "properties": {
@@ -64,9 +64,9 @@ const baseSchema = {
                             "type": "array",
                             "description": "Min and max values"
                         },
-                        "subtree": {
+                        "ancestors": {
                             "type": "array",
-                            "description": "The subtree to search for"
+                            "description": "The names of ancestors to search for"
                         },
                         "minSimilarity": {
                             "type": "number",
@@ -144,8 +144,8 @@ const baseSchema = {
             "oneOf":[ 
                 { "required": ["field", "type", "notOneOf"] },
                 { "required": ["field", "type", "range"] },
-                { "required": ["field", "type", "subtree"] },
-                { "required": ["field", "type", "subtree", "minSimilarity"] },
+                { "required": ["field", "type", "ancestors"] },
+                { "required": ["field", "type", "ancestors", "minSimilarity"] },
                 { "required": ["field", "type", "minSimilarity"] },
             ],
             "properties": {
@@ -166,9 +166,9 @@ const baseSchema = {
                     "type": "array",
                     "description": "Min and max values"
                 },
-                "subtree": {
+                "ancestors": {
                     "type": "array",
-                    "description": "The subtree to search for"
+                    "description": "The ancestors to search for"
                 },
                 "minSimilarity": {
                     "type": "number",
@@ -249,7 +249,7 @@ const optionsObjectSchema = merge(cloneDeep(baseSchema), {
 });
 
 /**
- * Return a condition for highlighting rows (e.g., `subtree` for dendrogram tracks).
+ * Return a condition for highlighting rows (e.g., `ancestors` for dendrogram tracks).
  * @param {Object} highlitOption A `rowHighlight` object.
  * @returns {string|array|null} The condition for highlighting rows for a given field type. `null` if no proper condition found.
  */
@@ -281,7 +281,7 @@ export function getHighlightKeyByFieldType(type, condition = undefined) {
         if(!condition) {
             console.warn("`condition` is not properly provided, so we are just guessing a HighlightKey");
         }
-        return Array.isArray(condition) ? "subtree" : "minSimilarity";
+        return Array.isArray(condition) ? "ancestors" : "minSimilarity";
   }
 }
 

--- a/src/utils/select-rows.js
+++ b/src/utils/select-rows.js
@@ -27,7 +27,7 @@ export function selectRows(rowInfo, options, altOptions = null) {
             filterInfos.sort((a, b) => a.minSimilarity ? 1 : b.minSimilarity ? -1 : 0);
 
             filterInfos.forEach(info => {
-                const { field, type, notOneOf, range, subtree, minSimilarity } = info;
+                const { field, type, notOneOf, range, ancestors, minSimilarity } = info;
                 const aggFunction = options.rowInfoAttributes?.find(d => d.field === field)?.aggFunction;
                 const isMultipleFields = Array.isArray(field);
                 if(type === "nominal") {
@@ -55,11 +55,11 @@ export function selectRows(rowInfo, options, altOptions = null) {
                         // TODO: How to best support aggregation for `tree`?
                         return;
                     }
-                    // `tree` type filter can have both the `subtree` and `minSimilarity` filters in a single `filterInfo`.
-                    if(subtree) {
+                    // `tree` type filter can have both the `ancestors` and `minSimilarity` filters in a single `filterInfo`.
+                    if(ancestors) {
                         filteredRowInfo = filteredRowInfo.filter(d => d[1][field].reduce(
-                            // TODO: Remove `h === subtree[i]` when we always encode similarity distance in dendrogram.
-                            (a, h, i) => a && (i >= subtree.length || h === subtree[i] || h.name === subtree[i]), true)
+                            // TODO: Remove `h === ancestors[i]` when we always encode similarity distance in dendrogram.
+                            (a, h, i) => a && (i >= ancestors.length || h === ancestors[i] || h.name === ancestors[i]), true)
                         );
                     } 
                     if (minSimilarity) {
@@ -242,7 +242,7 @@ export function highlightRowsFromSearch(rowInfo, field, type, conditions, option
             const filteredRows = aggregatedRowInfo.filter(
                 d => getAggregatedValue(d[1], field, 'tree', aggFuncName).reduce(
                     // Check if a node have identical ancestors
-                    // TODO: Remove `curr === subtree[i]` when we always encode similarity distance in dendrogram.
+                    // TODO: Remove `curr === ancestors[i]` when we always encode similarity distance in dendrogram.
                     (accum, curr, i) => accum && (i > ancestors.length || curr === ancestors[i] || curr.name === ancestors[i]),
                     true
                 )

--- a/src/utils/select-rows.spec.js
+++ b/src/utils/select-rows.spec.js
@@ -228,7 +228,7 @@ describe('Helper functions for producing arrays of row indices for track.options
             rowFilter: [{
                 field: "t",
                 type: "tree",
-                subtree: ["root", "b1"]
+                ancestors: ["root", "b1"]
             }]
         };
         const selectedRows = selectRows(rowInfo, options);
@@ -262,7 +262,7 @@ describe('Helper functions for producing arrays of row indices for track.options
         expect(selectedRows).not.toContain(4);
     });
 
-    it('Should produce correct selectRows array after filtering on tree attribute using `subtree` and `minSimilarity`', () => {
+    it('Should produce correct selectRows array after filtering on tree attribute using `ancestors` and `minSimilarity`', () => {
         const rowInfo = [
             {"id": "a","t":[{"name":"root","dist":1},{"name":"b1","dist":0.5},{"name":"b2","dist":0.1},{"name":"node-a","dist":0}]},
             {"id": "b","t":[{"name":"root","dist":1},{"name":"b1","dist":0.5},{"name":"b2","dist":0.1},{"name":"node-b","dist":0}]},
@@ -275,7 +275,7 @@ describe('Helper functions for producing arrays of row indices for track.options
                 field: "t",
                 type: "tree",
                 minSimilarity: 0.2,
-                subtree: ["root", "b1"]
+                ancestors: ["root", "b1"]
             }]
         };
         const selectedRows = selectRows(rowInfo, options);
@@ -300,7 +300,7 @@ describe('Helper functions for producing arrays of row indices for track.options
                     field: "t",
                     type: "tree",
                     minSimilarity: 0.2,
-                    subtree: ["root", "b1"]
+                    ancestors: ["root", "b1"]
                 },
                 {
                     field: "id",
@@ -328,7 +328,7 @@ describe('Helper functions for producing arrays of row indices for track.options
                     field: "t",
                     type: "tree",
                     minSimilarity: 0.2,
-                    subtree: ["root", "b1"]
+                    ancestors: ["root", "b1"]
                 }
             ]
         };


### PR DESCRIPTION
Renamed `subtree` to `ancestors` in `HiGlassMeta` options for the clarity since the `subtree` options in filtering and sorting was finding nodes that have the identical 'ancestors'.

Fix #296 
