### PR TITLE
feat: allow adding a track from toolkit results using cistrome APIs

### DIFF
--- a/src/HiGlassMetaConsumer.js
+++ b/src/HiGlassMetaConsumer.js
@@ -163,7 +163,7 @@ const HiGlassMetaConsumer = forwardRef((props, ref) => {
                                 field: "column3",
                                 type: "genomic"
                             },
-                            y: {field: "column5", type: "quantitative", axis: 'right'},
+                            y: {field: "column5", type: "quantitative", axis: "right"},
                             opacity: { value: 0.7 },
                             // strokeWidth: {value: 1},
                             // stroke: {value: "#F28E2C"},
@@ -637,6 +637,7 @@ const HiGlassMetaConsumer = forwardRef((props, ref) => {
         setOptions(newOptions);
     }, [options]);
 
+    
     // Destroy the context menu upon any click.
     useEffect(() => {
         const clickHandler = () => { destroyContextMenu(); };

--- a/src/cistrome-api/bigwig.js
+++ b/src/cistrome-api/bigwig.js
@@ -5,348 +5,327 @@ import { tsvParseRows } from "d3-dsv";
 import { text } from "d3-request";
 
 const chrToAbs = (chrom, chromPos, chromInfo) => {
-  return chromInfo.chrPositions[chrom].pos + chromPos;
+    return chromInfo.chrPositions[chrom].pos + chromPos;
 };
 
 function parseChromsizesRows(data) {
-  const cumValues = [];
-  const chromLengths = {};
-  const chrPositions = {};
+    const cumValues = [];
+    const chromLengths = {};
+    const chrPositions = {};
 
-  let totalLength = 0;
+    let totalLength = 0;
 
-  for (let i = 0; i < data.length; i++) {
-    const length = Number(data[i][1]);
-    totalLength += length;
+    for (let i = 0; i < data.length; i++) {
+        const length = Number(data[i][1]);
+        totalLength += length;
 
-    const newValue = {
-      id: i,
-      chr: data[i][0],
-      pos: totalLength - length,
+        const newValue = {
+            id: i,
+            chr: data[i][0],
+            pos: totalLength - length,
+        };
+
+        cumValues.push(newValue);
+        chrPositions[newValue.chr] = newValue;
+        chromLengths[data[i][0]] = length;
+    }
+
+    return {
+        chrToAbs: ([chrName, chrPos]) =>
+            chrToAbs(chrName, chrPos, { chrPositions }),
+        cumPositions: cumValues,
+        chrPositions,
+        totalLength,
+        chromLengths,
     };
-
-    cumValues.push(newValue);
-    chrPositions[newValue.chr] = newValue;
-    chromLengths[data[i][0]] = length;
-  }
-
-  return {
-    chrToAbs: ([chrName, chrPos]) =>
-      chrToAbs(chrName, chrPos, { chrPositions }),
-    cumPositions: cumValues,
-    chrPositions,
-    totalLength,
-    chromLengths,
-  };
 }
 
 function ChromosomeInfo(filepath, success) {
-  const ret = {};
+    const ret = {};
 
-  ret.absToChr = (absPos) => (ret.chrPositions ? absToChr(absPos, ret) : null);
+    ret.absToChr = (absPos) => (ret.chrPositions ? absToChr(absPos, ret) : null);
 
-  ret.chrToAbs = ([chrName, chrPos] = []) =>
-    ret.chrPositions ? chrToAbs(chrName, chrPos, ret) : null;
+    ret.chrToAbs = ([chrName, chrPos] = []) =>
+        ret.chrPositions ? chrToAbs(chrName, chrPos, ret) : null;
 
-  return text(filepath, (error, chrInfoText) => {
-    if (error) {
-      // console.warn('Chromosome info not found at:', filepath);
-      if (success) success(null);
-    } else {
-      const data = tsvParseRows(chrInfoText);
-      const chromInfo = parseChromsizesRows(data);
+    return text(filepath, (error, chrInfoText) => {
+        if (error) {
+            // console.warn('Chromosome info not found at:', filepath);
+            if (success) success(null);
+        } else {
+            const data = tsvParseRows(chrInfoText);
+            const chromInfo = parseChromsizesRows(data);
 
-      Object.keys(chromInfo).forEach((key) => {
-        ret[key] = chromInfo[key];
-      });
-      if (success) success(ret);
-    }
-  });
+            Object.keys(chromInfo).forEach((key) => {
+                ret[key] = chromInfo[key];
+            });
+            if (success) success(ret);
+        }
+    });
 }
 
 const CistromeBigWigDataFetcher = function CistromeBigWigDataFetcher(HGC, ...args) {
-  if (!new.target) {
-    throw new Error(
-      'Uncaught TypeError: Class constructor cannot be invoked without "new"'
-    );
-  }
-
-  class CistromeBigWigDataFetcherClass {
-    constructor(dataConfig) {
-      this.dataConfig = dataConfig;
-      this.trackUid = slugid.nice();
-      this.bwFileHeader = null;
-      this.bwFile = null;
-      this.TILE_SIZE = 1024;
-
-      this.errorTxt = "";
-      this.dataPromises = [];
-      this.dataPromises.push(this.loadChromsizes(dataConfig));
-      // this.dataPromises.push(this.loadBBI(dataConfig));
-    }
-
-    loadChromsizes(dataConfig) {
-      if (dataConfig.chromSizesUrl) {
-        return new Promise((resolve) => {
-          ChromosomeInfo(dataConfig.chromSizesUrl, (chromInfo) => {
-            this.chromSizes = chromInfo;
-            resolve();
-          });
-        });
-      } else {
-        console.error(
-          'Please enter a "chromSizesUrl" field to the data config'
+    if (!new.target) {
+        throw new Error(
+            "Uncaught TypeError: Class constructor cannot be invoked without \"new\""
         );
-      }
-      return null;
     }
 
-    loadBBI(dataConfig) {
-      if (dataConfig.url) {
-        this.bwFile = new BigWig({
-          filehandle: new RemoteFile(dataConfig.url),
-        });
-        return this.bwFile.getHeader().then((h) => {
-          this.bwFileHeader = h;
-          console.log(this.bwFileHeader)
-        });
-      } else {
-        console.error('Please enter a "url" field to the data config');
-        return null;
-      }
-    }
+    class CistromeBigWigDataFetcherClass {
+        constructor(dataConfig) {
+            this.dataConfig = dataConfig;
+            this.trackUid = slugid.nice();
+            this.bwFileHeader = null;
+            this.bwFile = null;
+            this.TILE_SIZE = 1024;
 
-    tilesetInfo(callback) {
-      this.tilesetInfoLoading = true;
-
-      return Promise.all(this.dataPromises)
-        .then(() => {
-          this.tilesetInfoLoading = false;
-
-          let retVal = {};
-
-          const totalLength = this.chromSizes.totalLength;
-
-          retVal = {
-            tile_size: this.TILE_SIZE,
-            max_zoom: Math.ceil(
-              Math.log(totalLength / this.TILE_SIZE) / Math.log(2)
-            ),
-            max_width: 2 ** Math.ceil(Math.log(totalLength) / Math.log(2)),
-            min_pos: [0],
-            max_pos: [totalLength],
-          };
-
-          if (callback) {
-            callback(retVal);
-          }
-
-          return retVal;
-        })
-        .catch((err) => {
-          this.tilesetInfoLoading = false;
-
-          console.error(err);
-
-          if (callback) {
-            callback({
-              error: `Error parsing bigwig: ${err}`,
-            });
-          }
-        });
-    }
-
-    fetchTilesDebounced(receivedTiles, tileIds) {
-      const tiles = {};
-
-      const validTileIds = [];
-      const tilePromises = [];
-
-      for (const tileId of tileIds) {
-        const parts = tileId.split(".");
-        const z = parseInt(parts[0], 10);
-        const x = parseInt(parts[1], 10);
-
-        if (Number.isNaN(x) || Number.isNaN(z)) {
-          console.warn("Invalid tile zoom or position:", z, x);
-          continue;
+            this.errorTxt = "";
+            this.dataPromises = [];
+            this.dataPromises.push(this.loadChromsizes(dataConfig));
+            // this.dataPromises.push(this.loadBBI(dataConfig));
         }
 
-        validTileIds.push(tileId);
-        tilePromises.push(this.tile(z, x));
-      }
-
-      Promise.all(tilePromises).then((values) => {
-        for (let i = 0; i < values.length; i++) {
-          const validTileId = validTileIds[i];
-          tiles[validTileId] = values[i];
-          tiles[validTileId].tilePositionId = validTileId;
-        }
-
-        receivedTiles(tiles);
-      });
-      // tiles = tileResponseToData(tiles, null, tileIds);
-      return tiles;
-    }
-
-    tile(z, x) {
-      return this.tilesetInfo().then((tsInfo) => {
-        const tileWidth = +tsInfo.max_width / 2 ** +z;
-
-        const recordPromises = [];
-
-        const tile = {
-          tilePos: [x],
-          tileId: "bigwig." + z + "." + x,
-          zoomLevel: z,
-        };
-
-        // get the bounds of the tile
-        const minXOriginal = tsInfo.min_pos[0] + x * tileWidth;
-        let minX = minXOriginal;
-        const maxX = tsInfo.min_pos[0] + (x + 1) * tileWidth;
-
-        // const basesPerPixel = this.determineScale(minX, maxX);
-        const basesPerBin = (maxX - minX) / this.TILE_SIZE;
-
-        const binStarts = [];
-        for (let i = 0; i < this.TILE_SIZE; i++) {
-          binStarts.push(minX + i * basesPerBin);
-        }
-
-        const { chromLengths, cumPositions } = this.chromSizes;
-
-        for (let i = 0; i < cumPositions.length; i++) {
-          const chromName = cumPositions[i].chr;
-          const chromStart = cumPositions[i].pos;
-          const chromEnd = cumPositions[i].pos + chromLengths[chromName];
-
-          let startPos, endPos;
-
-          if (chromStart <= minX && minX < chromEnd) {
-            // start of the visible region is within this chromosome
-
-            if (maxX > chromEnd) {
-              // the visible region extends beyond the end of this chromosome
-              // fetch from the start until the end of the chromosome
-              startPos = minX - chromStart;
-              endPos = chromEnd - chromStart;
-              recordPromises.push(
-                fetch('http://develop.cistrome.org/cistrome/samples/1/track?chrom=chr8&start_pos=1000000&end_pos=1100000&bin_length=500')
-                // fetch(`http://develop.cistrome.org/cistrome/samples/${this.dataConfig.cid}/track?chrom=${chromName}&start_pos=${startPos}&end_pos=${endPos}&bin_length=${basesPerBin}`)
-                  // .getFeatures(chromName, startPos, endPos, {
-                  //   scale: 1 / basesPerPixel,
-                  // })
-                  .then((values) => {
-                    console.log(values);
-                    values.forEach((v) => {
-                      v["startAbs"] = HGC.utils.chrToAbs(
-                        chromName,
-                        v.start,
-                        this.chromSizes
-                      );
-                      v["endAbs"] = HGC.utils.chrToAbs(
-                        chromName,
-                        v.end,
-                        this.chromSizes
-                      );
+        loadChromsizes(dataConfig) {
+            if (dataConfig.chromSizesUrl) {
+                return new Promise((resolve) => {
+                    ChromosomeInfo(dataConfig.chromSizesUrl, (chromInfo) => {
+                        this.chromSizes = chromInfo;
+                        resolve();
                     });
-                    return values;
-                  })
-              );
-
-              minX = chromEnd;
+                });
             } else {
-              startPos = Math.floor(minX - chromStart);
-              endPos = Math.ceil(maxX - chromStart);
-              recordPromises.push(
-                fetch(`http://develop.cistrome.org/cistrome/samples/${this.dataConfig.cid}/track?chrom=${chromName}&start_pos=${startPos}&end_pos=${endPos}&bin_length=${basesPerBin}`)
-                  // .getFeatures(chromName, startPos, endPos, {
-                  //   scale: 1 / basesPerPixel,
-                  // })
-                  .then((values) => {
-                    console.log(values);
-                    values.forEach((v) => {
-                      v["startAbs"] = HGC.utils.chrToAbs(
-                        chromName,
-                        v.start,
-                        this.chromSizes
-                      );
-                      v["endAbs"] = HGC.utils.chrToAbs(
-                        chromName,
-                        v.end,
-                        this.chromSizes
-                      );
+                console.error(
+                    "Please enter a \"chromSizesUrl\" field to the data config"
+                );
+            }
+            return null;
+        }
+
+        loadBBI(dataConfig) {
+            if (dataConfig.url) {
+                this.bwFile = new BigWig({
+                    filehandle: new RemoteFile(dataConfig.url),
+                });
+                return this.bwFile.getHeader().then((h) => {
+                    this.bwFileHeader = h;
+                    console.log(this.bwFileHeader);
+                });
+            } else {
+                console.error("Please enter a \"url\" field to the data config");
+                return null;
+            }
+        }
+
+        tilesetInfo(callback) {
+            this.tilesetInfoLoading = true;
+
+            return Promise.all(this.dataPromises)
+                .then(() => {
+                    this.tilesetInfoLoading = false;
+
+                    let retVal = {};
+
+                    const totalLength = this.chromSizes.totalLength;
+
+                    retVal = {
+                        tile_size: this.TILE_SIZE,
+                        max_zoom: Math.ceil(
+                            Math.log(totalLength / this.TILE_SIZE) / Math.log(2)
+                        ),
+                        max_width: 2 ** Math.ceil(Math.log(totalLength) / Math.log(2)),
+                        min_pos: [0],
+                        max_pos: [totalLength],
+                    };
+
+                    if (callback) {
+                        callback(retVal);
+                    }
+
+                    return retVal;
+                })
+                .catch((err) => {
+                    this.tilesetInfoLoading = false;
+
+                    console.error(err);
+
+                    if (callback) {
+                        callback({
+                            error: `Error parsing bigwig: ${err}`,
+                        });
+                    }
+                });
+        }
+
+        fetchTilesDebounced(receivedTiles, tileIds) {
+            const tiles = {};
+
+            const validTileIds = [];
+            const tilePromises = [];
+
+            for (const tileId of tileIds) {
+                const parts = tileId.split(".");
+                const z = parseInt(parts[0], 10);
+                const x = parseInt(parts[1], 10);
+
+                if (Number.isNaN(x) || Number.isNaN(z)) {
+                    console.warn("Invalid tile zoom or position:", z, x);
+                    continue;
+                }
+
+                validTileIds.push(tileId);
+                tilePromises.push(this.tile(z, x));
+            }
+
+            Promise.all(tilePromises).then((values) => {
+                for (let i = 0; i < values.length; i++) {
+                    const validTileId = validTileIds[i];
+                    tiles[validTileId] = values[i];
+                    tiles[validTileId].tilePositionId = validTileId;
+                }
+
+                receivedTiles(tiles);
+            });
+            // tiles = tileResponseToData(tiles, null, tileIds);
+            return tiles;
+        }
+
+        tile(z, x) {
+            return this.tilesetInfo().then((tsInfo) => {
+                const tileWidth = +tsInfo.max_width / 2 ** +z;
+
+                const recordPromises = [];
+
+                const tile = {
+                    tilePos: [x],
+                    tileId: "bigwig." + z + "." + x,
+                    zoomLevel: z,
+                };
+
+                // get the bounds of the tile
+                const minXOriginal = tsInfo.min_pos[0] + x * tileWidth;
+                let minX = minXOriginal;
+                const maxX = tsInfo.min_pos[0] + (x + 1) * tileWidth;
+
+                // const basesPerPixel = this.determineScale(minX, maxX);
+                const basesPerBin = 1000; // (maxX - minX) / this.TILE_SIZE;
+
+                const binStarts = [];
+                for (let i = 0; i < this.TILE_SIZE; i++) {
+                    binStarts.push(minX + i * basesPerBin);
+                }
+
+                const { chromLengths, cumPositions } = this.chromSizes;
+
+                for (let i = 0; i < cumPositions.length; i++) {
+                    const chromName = cumPositions[i].chr;
+                    const chromStart = cumPositions[i].pos;
+                    const chromEnd = cumPositions[i].pos + chromLengths[chromName];
+
+                    let startPos, endPos;
+
+                    if (chromStart <= minX && minX < chromEnd) {
+                        // start of the visible region is within this chromosome
+
+                        if (maxX > chromEnd) {
+                            // the visible region extends beyond the end of this chromosome
+                            // fetch from the start until the end of the chromosome
+                            startPos = minX - chromStart;
+                            endPos = chromEnd - chromStart;
+                            recordPromises.push(
+                                fetch(`http://develop.cistrome.org/cistrome/samples/${this.dataConfig.cid}/track?chrom=${chromName}&start_pos=${startPos}&end_pos=${endPos}&bin_length=${basesPerBin}`)
+                                // fetch("http://develop.cistrome.org/cistrome/samples/1/track?chrom=chr8&start_pos=1000000&end_pos=1100000&bin_length=500")
+                                // fetch(`http://develop.cistrome.org/cistrome/samples/${this.dataConfig.cid}/track?chrom=${chromName}&start_pos=${startPos}&end_pos=${endPos}&bin_length=${basesPerBin}`)
+                                    .then((response) => response.json())
+                                    .then((data) => {
+                                        const { values, multiplier, bin_size } = data;
+                                        return values.map((v, i) => {
+                                            return {
+                                                value: v / multiplier,
+                                                start: chromStart + startPos + i * bin_size,
+                                                end: chromStart + startPos + (i + 1) * bin_size,
+                                            };
+                                        });
+                                    })
+                            );
+
+                            minX = chromEnd;
+                        } else {
+                            startPos = Math.floor(minX - chromStart);
+                            endPos = Math.ceil(maxX - chromStart);
+                            recordPromises.push(
+                                fetch(`http://develop.cistrome.org/cistrome/samples/${this.dataConfig.cid}/track?chrom=${chromName}&start_pos=${startPos}&end_pos=${endPos}&bin_length=${basesPerBin}`)
+                                    .then((response) => response.json())
+                                    .then((data) => {
+                                        const { values, multiplier, bin_size } = data;
+                                        return values.map((v, i) => {
+                                            return {
+                                                value: v / multiplier,
+                                                start: chromStart + startPos + i * bin_size,
+                                                end: chromStart + startPos + (i + 1) * bin_size,
+                                            };
+                                        });
+                                    })
+                            );
+                            break;
+                        }
+                    }
+                }
+
+                return Promise.all(recordPromises).then((v) => {
+                    const values = v.flat();
+
+                    var dense = [];
+                    for (var i = 0; i < this.TILE_SIZE; i++) {
+                        dense.push(null);
+                    }
+
+                    // Currently we use the same binning strategy in all cases (basesPerBin =>< basesPerBinInFile)
+                    binStarts.forEach((curStart, index) => {
+                        if (curStart < minXOriginal || curStart > maxX) {
+                            return;
+                        }
+                        const filtered = values
+                            .filter((v) => {
+                                return curStart >= v.startAbs && curStart < v.endAbs;
+                            })
+                            .map((v) => v.score);
+                        dense[index] = filtered.length > 0 ? filtered[0] : null;
                     });
-                    return values;
-                  })
-              );
-              break;
-            }
-          }
+
+                    tile.tabularData = values;
+                    console.log(values);
+                    return tile;
+                });
+            });
         }
 
-        return Promise.all(recordPromises).then((v) => {
-          const values = v.flat();
+        // We never want to request more than 1024 * 20 elements from the file.
+        determineScale(minX, maxX) {
+            const reductionLevels = [1];
+            const numRequestedElements = maxX - minX;
 
-          var dense = [];
-          for (var i = 0; i < this.TILE_SIZE; i++) {
-            dense.push(null);
-          }
+            this.bwFileHeader.zoomLevels.forEach((z) => {
+                reductionLevels.push(z.reductionLevel);
+            });
 
-          // Currently we use the same binning strategy in all cases (basesPerBin =>< basesPerBinInFile)
-          binStarts.forEach((curStart, index) => {
-            if (curStart < minXOriginal || curStart > maxX) {
-              return;
+            for (var i = 0; i < reductionLevels.length; i++) {
+                const rl = reductionLevels[i];
+                const numElementsFromFile = numRequestedElements / rl;
+                if (numElementsFromFile <= this.TILE_SIZE * 20) {
+                    return rl;
+                }
             }
-            const filtered = values
-              .filter((v) => {
-                return curStart >= v.startAbs && curStart < v.endAbs;
-              })
-              .map((v) => v.score);
-            dense[index] = filtered.length > 0 ? filtered[0] : null;
-          });
 
-          tile.min_value = Math.min(...dense);
-          tile.max_value = Math.max(...dense);
-
-          const dde = new HGC.utils.DenseDataExtrema1D(dense);
-          tile.dense = dense;
-          tile.denseDataExtrema = dde;
-          tile.minNonZero = dde.minNonZeroInTile;
-          tile.maxNonZero = dde.maxNonZeroInTile;
-          return tile;
-        });
-      });
-    }
-
-    // We never want to request more than 1024 * 20 elements from the file.
-    determineScale(minX, maxX) {
-      const reductionLevels = [1];
-      const numRequestedElements = maxX - minX;
-
-      this.bwFileHeader.zoomLevels.forEach((z) => {
-        reductionLevels.push(z.reductionLevel);
-      });
-
-      for (var i = 0; i < reductionLevels.length; i++) {
-        const rl = reductionLevels[i];
-        const numElementsFromFile = numRequestedElements / rl;
-        if (numElementsFromFile <= this.TILE_SIZE * 20) {
-          return rl;
+            // return the highest reductionLevel, if we could not find anything better
+            return reductionLevels.slice(-1)[0];
         }
-      }
-
-      // return the highest reductionLevel, if we could not find anything better
-      return reductionLevels.slice(-1)[0];
     }
-  }
 
-  return new CistromeBigWigDataFetcherClass(...args);
+    return new CistromeBigWigDataFetcherClass(...args);
 }; // end function wrapper
 
 CistromeBigWigDataFetcher.config = {
-  type: "cistrome-bigwig",
+    type: "cistrome-bigwig",
 };
 
 export default CistromeBigWigDataFetcher;

--- a/src/cistrome-api/bigwig.js
+++ b/src/cistrome-api/bigwig.js
@@ -1,0 +1,352 @@
+import slugid from "slugid";
+import { BigWig } from "@gmod/bbi";
+import { RemoteFile } from "generic-filehandle";
+import { tsvParseRows } from "d3-dsv";
+import { text } from "d3-request";
+
+const chrToAbs = (chrom, chromPos, chromInfo) => {
+  return chromInfo.chrPositions[chrom].pos + chromPos;
+};
+
+function parseChromsizesRows(data) {
+  const cumValues = [];
+  const chromLengths = {};
+  const chrPositions = {};
+
+  let totalLength = 0;
+
+  for (let i = 0; i < data.length; i++) {
+    const length = Number(data[i][1]);
+    totalLength += length;
+
+    const newValue = {
+      id: i,
+      chr: data[i][0],
+      pos: totalLength - length,
+    };
+
+    cumValues.push(newValue);
+    chrPositions[newValue.chr] = newValue;
+    chromLengths[data[i][0]] = length;
+  }
+
+  return {
+    chrToAbs: ([chrName, chrPos]) =>
+      chrToAbs(chrName, chrPos, { chrPositions }),
+    cumPositions: cumValues,
+    chrPositions,
+    totalLength,
+    chromLengths,
+  };
+}
+
+function ChromosomeInfo(filepath, success) {
+  const ret = {};
+
+  ret.absToChr = (absPos) => (ret.chrPositions ? absToChr(absPos, ret) : null);
+
+  ret.chrToAbs = ([chrName, chrPos] = []) =>
+    ret.chrPositions ? chrToAbs(chrName, chrPos, ret) : null;
+
+  return text(filepath, (error, chrInfoText) => {
+    if (error) {
+      // console.warn('Chromosome info not found at:', filepath);
+      if (success) success(null);
+    } else {
+      const data = tsvParseRows(chrInfoText);
+      const chromInfo = parseChromsizesRows(data);
+
+      Object.keys(chromInfo).forEach((key) => {
+        ret[key] = chromInfo[key];
+      });
+      if (success) success(ret);
+    }
+  });
+}
+
+const CistromeBigWigDataFetcher = function CistromeBigWigDataFetcher(HGC, ...args) {
+  if (!new.target) {
+    throw new Error(
+      'Uncaught TypeError: Class constructor cannot be invoked without "new"'
+    );
+  }
+
+  class CistromeBigWigDataFetcherClass {
+    constructor(dataConfig) {
+      this.dataConfig = dataConfig;
+      this.trackUid = slugid.nice();
+      this.bwFileHeader = null;
+      this.bwFile = null;
+      this.TILE_SIZE = 1024;
+
+      this.errorTxt = "";
+      this.dataPromises = [];
+      this.dataPromises.push(this.loadChromsizes(dataConfig));
+      // this.dataPromises.push(this.loadBBI(dataConfig));
+    }
+
+    loadChromsizes(dataConfig) {
+      if (dataConfig.chromSizesUrl) {
+        return new Promise((resolve) => {
+          ChromosomeInfo(dataConfig.chromSizesUrl, (chromInfo) => {
+            this.chromSizes = chromInfo;
+            resolve();
+          });
+        });
+      } else {
+        console.error(
+          'Please enter a "chromSizesUrl" field to the data config'
+        );
+      }
+      return null;
+    }
+
+    loadBBI(dataConfig) {
+      if (dataConfig.url) {
+        this.bwFile = new BigWig({
+          filehandle: new RemoteFile(dataConfig.url),
+        });
+        return this.bwFile.getHeader().then((h) => {
+          this.bwFileHeader = h;
+          console.log(this.bwFileHeader)
+        });
+      } else {
+        console.error('Please enter a "url" field to the data config');
+        return null;
+      }
+    }
+
+    tilesetInfo(callback) {
+      this.tilesetInfoLoading = true;
+
+      return Promise.all(this.dataPromises)
+        .then(() => {
+          this.tilesetInfoLoading = false;
+
+          let retVal = {};
+
+          const totalLength = this.chromSizes.totalLength;
+
+          retVal = {
+            tile_size: this.TILE_SIZE,
+            max_zoom: Math.ceil(
+              Math.log(totalLength / this.TILE_SIZE) / Math.log(2)
+            ),
+            max_width: 2 ** Math.ceil(Math.log(totalLength) / Math.log(2)),
+            min_pos: [0],
+            max_pos: [totalLength],
+          };
+
+          if (callback) {
+            callback(retVal);
+          }
+
+          return retVal;
+        })
+        .catch((err) => {
+          this.tilesetInfoLoading = false;
+
+          console.error(err);
+
+          if (callback) {
+            callback({
+              error: `Error parsing bigwig: ${err}`,
+            });
+          }
+        });
+    }
+
+    fetchTilesDebounced(receivedTiles, tileIds) {
+      const tiles = {};
+
+      const validTileIds = [];
+      const tilePromises = [];
+
+      for (const tileId of tileIds) {
+        const parts = tileId.split(".");
+        const z = parseInt(parts[0], 10);
+        const x = parseInt(parts[1], 10);
+
+        if (Number.isNaN(x) || Number.isNaN(z)) {
+          console.warn("Invalid tile zoom or position:", z, x);
+          continue;
+        }
+
+        validTileIds.push(tileId);
+        tilePromises.push(this.tile(z, x));
+      }
+
+      Promise.all(tilePromises).then((values) => {
+        for (let i = 0; i < values.length; i++) {
+          const validTileId = validTileIds[i];
+          tiles[validTileId] = values[i];
+          tiles[validTileId].tilePositionId = validTileId;
+        }
+
+        receivedTiles(tiles);
+      });
+      // tiles = tileResponseToData(tiles, null, tileIds);
+      return tiles;
+    }
+
+    tile(z, x) {
+      return this.tilesetInfo().then((tsInfo) => {
+        const tileWidth = +tsInfo.max_width / 2 ** +z;
+
+        const recordPromises = [];
+
+        const tile = {
+          tilePos: [x],
+          tileId: "bigwig." + z + "." + x,
+          zoomLevel: z,
+        };
+
+        // get the bounds of the tile
+        const minXOriginal = tsInfo.min_pos[0] + x * tileWidth;
+        let minX = minXOriginal;
+        const maxX = tsInfo.min_pos[0] + (x + 1) * tileWidth;
+
+        // const basesPerPixel = this.determineScale(minX, maxX);
+        const basesPerBin = (maxX - minX) / this.TILE_SIZE;
+
+        const binStarts = [];
+        for (let i = 0; i < this.TILE_SIZE; i++) {
+          binStarts.push(minX + i * basesPerBin);
+        }
+
+        const { chromLengths, cumPositions } = this.chromSizes;
+
+        for (let i = 0; i < cumPositions.length; i++) {
+          const chromName = cumPositions[i].chr;
+          const chromStart = cumPositions[i].pos;
+          const chromEnd = cumPositions[i].pos + chromLengths[chromName];
+
+          let startPos, endPos;
+
+          if (chromStart <= minX && minX < chromEnd) {
+            // start of the visible region is within this chromosome
+
+            if (maxX > chromEnd) {
+              // the visible region extends beyond the end of this chromosome
+              // fetch from the start until the end of the chromosome
+              startPos = minX - chromStart;
+              endPos = chromEnd - chromStart;
+              recordPromises.push(
+                fetch('http://develop.cistrome.org/cistrome/samples/1/track?chrom=chr8&start_pos=1000000&end_pos=1100000&bin_length=500')
+                // fetch(`http://develop.cistrome.org/cistrome/samples/${this.dataConfig.cid}/track?chrom=${chromName}&start_pos=${startPos}&end_pos=${endPos}&bin_length=${basesPerBin}`)
+                  // .getFeatures(chromName, startPos, endPos, {
+                  //   scale: 1 / basesPerPixel,
+                  // })
+                  .then((values) => {
+                    console.log(values);
+                    values.forEach((v) => {
+                      v["startAbs"] = HGC.utils.chrToAbs(
+                        chromName,
+                        v.start,
+                        this.chromSizes
+                      );
+                      v["endAbs"] = HGC.utils.chrToAbs(
+                        chromName,
+                        v.end,
+                        this.chromSizes
+                      );
+                    });
+                    return values;
+                  })
+              );
+
+              minX = chromEnd;
+            } else {
+              startPos = Math.floor(minX - chromStart);
+              endPos = Math.ceil(maxX - chromStart);
+              recordPromises.push(
+                fetch(`http://develop.cistrome.org/cistrome/samples/${this.dataConfig.cid}/track?chrom=${chromName}&start_pos=${startPos}&end_pos=${endPos}&bin_length=${basesPerBin}`)
+                  // .getFeatures(chromName, startPos, endPos, {
+                  //   scale: 1 / basesPerPixel,
+                  // })
+                  .then((values) => {
+                    console.log(values);
+                    values.forEach((v) => {
+                      v["startAbs"] = HGC.utils.chrToAbs(
+                        chromName,
+                        v.start,
+                        this.chromSizes
+                      );
+                      v["endAbs"] = HGC.utils.chrToAbs(
+                        chromName,
+                        v.end,
+                        this.chromSizes
+                      );
+                    });
+                    return values;
+                  })
+              );
+              break;
+            }
+          }
+        }
+
+        return Promise.all(recordPromises).then((v) => {
+          const values = v.flat();
+
+          var dense = [];
+          for (var i = 0; i < this.TILE_SIZE; i++) {
+            dense.push(null);
+          }
+
+          // Currently we use the same binning strategy in all cases (basesPerBin =>< basesPerBinInFile)
+          binStarts.forEach((curStart, index) => {
+            if (curStart < minXOriginal || curStart > maxX) {
+              return;
+            }
+            const filtered = values
+              .filter((v) => {
+                return curStart >= v.startAbs && curStart < v.endAbs;
+              })
+              .map((v) => v.score);
+            dense[index] = filtered.length > 0 ? filtered[0] : null;
+          });
+
+          tile.min_value = Math.min(...dense);
+          tile.max_value = Math.max(...dense);
+
+          const dde = new HGC.utils.DenseDataExtrema1D(dense);
+          tile.dense = dense;
+          tile.denseDataExtrema = dde;
+          tile.minNonZero = dde.minNonZeroInTile;
+          tile.maxNonZero = dde.maxNonZeroInTile;
+          return tile;
+        });
+      });
+    }
+
+    // We never want to request more than 1024 * 20 elements from the file.
+    determineScale(minX, maxX) {
+      const reductionLevels = [1];
+      const numRequestedElements = maxX - minX;
+
+      this.bwFileHeader.zoomLevels.forEach((z) => {
+        reductionLevels.push(z.reductionLevel);
+      });
+
+      for (var i = 0; i < reductionLevels.length; i++) {
+        const rl = reductionLevels[i];
+        const numElementsFromFile = numRequestedElements / rl;
+        if (numElementsFromFile <= this.TILE_SIZE * 20) {
+          return rl;
+        }
+      }
+
+      // return the highest reductionLevel, if we could not find anything better
+      return reductionLevels.slice(-1)[0];
+    }
+  }
+
+  return new CistromeBigWigDataFetcherClass(...args);
+}; // end function wrapper
+
+CistromeBigWigDataFetcher.config = {
+  type: "cistrome-bigwig",
+};
+
+export default CistromeBigWigDataFetcher;

--- a/src/demo/CistromeExplorer.js
+++ b/src/demo/CistromeExplorer.js
@@ -15,10 +15,11 @@ import { publishHelpTooltip, destroyTooltip } from "../Tooltip.js";
 
 import "./CistromeExplorer.scss";
 
-import StackedBarTrack from "higlass-multivec/es/StackedBarTrack";
-import ScaleLegendTrack from "../scale-legend/ScaleLegendTrack";
-import { default as higlassRegister } from "higlass-register";
-import gosling from "gosling.js";
+import StackedBarTrack from 'higlass-multivec/es/StackedBarTrack';
+import ScaleLegendTrack from '../scale-legend/ScaleLegendTrack';
+import CistromeBigWigDataFetcher from '../cistrome-api/bigwig';
+import { default as higlassRegister } from 'higlass-register';
+import gosling from 'gosling.js';
 
 gosling.init();
  
@@ -33,6 +34,11 @@ higlassRegister({
     track: ScaleLegendTrack,
     config: ScaleLegendTrack.config,
 });
+
+higlassRegister(
+    { dataFetcher: CistromeBigWigDataFetcher, config: CistromeBigWigDataFetcher.config },
+    { pluginType: "dataFetcher" }
+);
 
 export default function CistromeExplorer() {
     

--- a/src/demo/CistromeExplorer.js
+++ b/src/demo/CistromeExplorer.js
@@ -15,11 +15,14 @@ import { publishHelpTooltip, destroyTooltip } from "../Tooltip.js";
 
 import "./CistromeExplorer.scss";
 
-import StackedBarTrack from 'higlass-multivec/es/StackedBarTrack';
-import ScaleLegendTrack from '../scale-legend/ScaleLegendTrack';
-import CistromeBigWigDataFetcher from '../cistrome-api/bigwig';
-import { default as higlassRegister } from 'higlass-register';
-import gosling from 'gosling.js';
+import StackedBarTrack from "higlass-multivec/es/StackedBarTrack";
+import ScaleLegendTrack from "../scale-legend/ScaleLegendTrack";
+import CistromeBigWigDataFetcher from "../cistrome-api/bigwig";
+import { default as higlassRegister } from "higlass-register";
+import gosling from "gosling.js";
+
+import {theme} from "../viewconfigs/horizontal-multivec-1.js";
+import { REMOVE_ALLOWED_TAG_TRACKID } from "../HiGlassMetaConsumer";
 
 gosling.init();
  
@@ -78,8 +81,8 @@ export default function CistromeExplorer() {
                     // check whether chr names are parsable
                     const chr = obj.column1;
                     if(!chr) return;
-                    const c = chr.replace('chr', '');
-                    if(!((1 <= +c && +c <= 22) || c === 'x' || c === 'X' || c === 'y' || c === 'Y')) return;
+                    const c = chr.replace("chr", "");
+                    if(!((1 <= +c && +c <= 22) || c === "x" || c === "X" || c === "y" || c === "Y")) return;
                     data.push(obj);
                 });
                 setLocalBed({ data, name: fileReader.fileName });
@@ -156,6 +159,60 @@ export default function CistromeExplorer() {
             },
             height: 200,
         }, firstViewUid, "top");
+    }, [addNewTrack, selectedDemo]);
+
+    // Callback function for adding a cistrome track from toolkit.
+    const onAddToolkitTrack = useCallback((cid, gsm) => {
+        const viewId = demos[selectedDemo].viewConfig.views[0].uid;
+        const newTrackDef = {
+            "data": {
+                "type": "cistrome-bigwig",
+                cid,
+                "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.chrom.sizes",
+            },
+            uid: "cistrome-" + cid + REMOVE_ALLOWED_TAG_TRACKID,
+            "type": "gosling-track",
+            "options": {
+                showMousePosition: true,
+                mousePositionColor: "black",
+                name: `Cistrome ID ${cid} | ${gsm}`,
+                labelPosition: "topLeft",
+                fontSize: 12,
+                labelColor: "black",
+                labelShowResolution: false,
+                labelBackgroundColor: "#F6F6F6",
+                labelTextOpacity: 0.6,
+                labelLeftMargin: 4,
+                labelRightMargin: 0,
+                labelTopMargin: 2,
+                labelBottomMargin: 0,
+                backgroundColor: "transparent",
+                theme, 
+                spec: {
+                    "data": {
+                        "type": "cistrome-bigwig",
+                        "cid": "870",
+                        "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.chrom.sizes",
+                    },
+                    mark: "bar",
+                    x: { field: "start", type: "genomic" },
+                    xe: { field: "end", type: "genomic" },
+                    y: { field: "value", type: "quantitative", axis: "none" },
+                    color: { value: "#22908D" },
+                    tooltip: [
+                        { field: "start", type: "genomic" },
+                        { field: "end", type: "genomic" },
+                        { field: "value", type: "quantitative" },
+                    ],
+                    style: { outlineWidth: 0 }, // background: "gray" },
+                    width: 100,
+                    height: 30
+                },
+            },
+            "width": 100,
+            "height": 40
+        };
+        addNewTrack(newTrackDef, viewId, "top");
     }, [addNewTrack, selectedDemo]);
 
     // Drag event for resizing heatmaps
@@ -557,7 +614,7 @@ export default function CistromeExplorer() {
                         isVisible={isToolkitVisible}
                         intervalAPIParams={toolkitParams}
                         geneAPIParams={geneToolkitParams}
-                        onAddTrack={onAddTrack}
+                        onAddTrack={onAddToolkitTrack}
                     />
                 </div>
                 <div className="settings" style={{

--- a/src/demo/CistromeToolkit.js
+++ b/src/demo/CistromeToolkit.js
@@ -508,11 +508,8 @@ export default function CistromeToolkit(props) {
                         rows={selectedRequestIndex !== undefined ? requestHistory[selectedRequestIndex].rows : []}
                         selectedRows={selectedRowIndexes}
                         expoNotations={["Overlap Ratio", "Regulatory Potential"]}
-                        onButton={(row) => {
-                            onAddTrack({
-                                species: row["Species"],
-                                factor: row["Factor"],
-                            });
+                        onButton={(cid, gsm) => {
+                            onAddTrack(cid, gsm);
                             setIsVisible(false);
                         }}
                     />

--- a/src/demo/DataTable.js
+++ b/src/demo/DataTable.js
@@ -184,13 +184,19 @@ export default function DataTable(props) {
             ) : null);
             const dataCells = columns.map((c, j) => {
                 return (
-                    <td key={j}>
+                    <td key={j} >
                         {expoNotations.includes(c) && +d[c] ? Number.parseFloat(d[c]).toExponential(2) : d[c]}
                     </td>
                 );
             });
+            const cid = d["CistromeDB ID"];
+            const gsm = d["GEO/ENCODE ID"];
             return (
-                <tr key={i} className={"data-table-row"}>
+                <tr 
+                    key={i} 
+                    className={"data-table-row"}
+                    onClick={() => { if(cid) onButton(cid, gsm) }}
+                >
                     {/* {buttonCell} */}
                     {dataCells}
                 </tr>
@@ -235,34 +241,6 @@ export default function DataTable(props) {
                     gridColumnGap: 6
                 }}
             >
-                <span 
-                    style={{
-                        textAlign: "left",
-                        fontWeight: 600,
-                        color: "gray",
-                        cursor: "not-allowed"
-                    }}
-                    // onClick={() => onButton({
-                    //     Factor: selectedFactor,
-                    //     Species: 'Homo sapiens'
-                    // })}
-                >
-                    <select 
-                        onChange={e => { setSelectedFactor(e.target.value); }} 
-                        defaultValue={uniqueFactors[0]}
-                    >
-                        {uniqueFactors.map(factor => (
-                            <option 
-                                key={factor} 
-                                value={factor} 
-                            >
-                                {factor}
-                            </option>
-                        ))}
-                    </select>
-                    &nbsp;&nbsp;
-                    {"  Add samples to visualization"}
-                </span>
                 <div 
                     style={{
                         textAlign: "right",

--- a/src/demo/DataTable.scss
+++ b/src/demo/DataTable.scss
@@ -10,6 +10,12 @@
     thead {
         border-bottom: 1px solid black;
     }
+    .data-table-row {
+        cursor: pointer;
+    }
+    .data-table-row:hover {
+        background: #e2f1ff;
+    }
     .data-table-row-selected {
         outline: 1px solid #00a3fe;
         background: #e2f1ff;

--- a/src/viewconfigs/horizontal-multivec-1.js
+++ b/src/viewconfigs/horizontal-multivec-1.js
@@ -41,40 +41,6 @@ export const hgDemoViewConfig1 = {
                         },
                         height: 25,
                     },
-{
-              "data": {
-                "type": "cistrome-bigwig",
-                "cid": "1",
-                // "url": "http://dbtoolkit.cistrome.org/api_bigwig?sid=1",
-                "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.chrom.sizes",
-              },
-              "uid": "bw",
-              "type": "bar",
-              "options": {
-                "labelPosition": "topLeft",
-                "labelColor": "black",
-                "labelTextOpacity": 0.6,
-                "barBorder": false,
-                "valueScaling": "linear",
-                "labelTopMargin": 2,
-                "labelLeftMargin": 4,
-                "labelBottomMargin": 0,
-                "labelRightMargin": 0,
-                "labelBackgroundColor": "#F6F6F6",
-                "labelShowResolution": false,
-                "backgroundColor": "#F6F6F6",
-                "minHeight": 100,
-                "colorbarPosition": "hidden",
-                "colorScale": ["gray"],
-                "zeroValueColor": "white",
-                "showMousePosition": true,
-                "mousePositionColor": "#000000",
-                "name": "Cistrome Track Using API"
-              },
-              "width": 100,
-              "height": 40
-            },
-
                     {
                         type: "horizontal-chromosome-labels",
                         server: "https://higlass.io/api/v1",
@@ -158,7 +124,7 @@ export const hgDemoViewConfig1 = {
                                 //    type: "quantitative",
                                 //    range: "warm",
                                 //},
-                                color: { value: 'gray' },
+                                color: { value: "gray" },
                                 tooltip: [
                                     { field: "MAPPED_TRAIT", type: "nominal", alt: "Trait" },
                                     { field: "LINK", type: "nominal", alt: "Link" },
@@ -373,6 +339,57 @@ export const hgDemoViewConfig1 = {
                         },
                         height: 78,
                     },
+                    // {
+                    //     "data": {
+                    //         "type": "cistrome-bigwig",
+                    //         "cid": "1",
+                    //         // "url": "http://dbtoolkit.cistrome.org/api_bigwig?sid=1",
+                    //         "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.chrom.sizes",
+                    //     },
+                    //     "uid": "bw-allow-remove-",
+                    //     "type": "gosling-track",
+                    //     "options": {
+                    //         showMousePosition: true,
+                    //         mousePositionColor: "black",
+                    //         name: "hg38 | GWAS",
+                    //         labelPosition: "topLeft",
+                    //         fontSize: 12,
+                    //         labelColor: "black",
+                    //         labelShowResolution: false,
+                    //         labelBackgroundColor: "#F6F6F6",
+                    //         labelTextOpacity: 0.6,
+                    //         labelLeftMargin: 4,
+                    //         labelRightMargin: 0,
+                    //         labelTopMargin: 2,
+                    //         labelBottomMargin: 0,
+                    //         backgroundColor: "transparent",
+                    //         theme, 
+                    //         spec: {
+                    //             "data": {
+                    //                 "type": "cistrome-bigwig",
+                    //                 "cid": "870",
+                    //                 // "url": "http://dbtoolkit.cistrome.org/api_bigwig?sid=1",
+                    //                 "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.chrom.sizes",
+                    //             },
+                    //             mark: "bar",
+                    //             x: { field: "start", type: "genomic" },
+                    //             xe: { field: "end", type: "genomic" },
+                    //             y: { field: "value", type: "quantitative", axis: "none" },
+                    //             color: { value: "#22908D" },
+                    //             tooltip: [
+                    //                 { field: "start", type: "genomic" },
+                    //                 { field: "end", type: "genomic" },
+                    //                 { field: "value", type: "quantitative" },
+                    //             ],
+                    //             style: { outlineWidth: 0 }, // background: "gray" },
+                    //             width: 100,
+                    //             height: 30
+                    //         },
+                    //     },
+                    //     "width": 100,
+                    //     "height": 40
+                    // },
+ 
                     {
                         type: "horizontal-stacked-bar",
                         uid: "cistrome-track-1-aggregated",

--- a/src/viewconfigs/horizontal-multivec-1.js
+++ b/src/viewconfigs/horizontal-multivec-1.js
@@ -41,6 +41,40 @@ export const hgDemoViewConfig1 = {
                         },
                         height: 25,
                     },
+{
+              "data": {
+                "type": "cistrome-bigwig",
+                "cid": "1",
+                // "url": "http://dbtoolkit.cistrome.org/api_bigwig?sid=1",
+                "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.chrom.sizes",
+              },
+              "uid": "bw",
+              "type": "bar",
+              "options": {
+                "labelPosition": "topLeft",
+                "labelColor": "black",
+                "labelTextOpacity": 0.6,
+                "barBorder": false,
+                "valueScaling": "linear",
+                "labelTopMargin": 2,
+                "labelLeftMargin": 4,
+                "labelBottomMargin": 0,
+                "labelRightMargin": 0,
+                "labelBackgroundColor": "#F6F6F6",
+                "labelShowResolution": false,
+                "backgroundColor": "#F6F6F6",
+                "minHeight": 100,
+                "colorbarPosition": "hidden",
+                "colorScale": ["gray"],
+                "zeroValueColor": "white",
+                "showMousePosition": true,
+                "mousePositionColor": "#000000",
+                "name": "Cistrome Track Using API"
+              },
+              "width": 100,
+              "height": 40
+            },
+
                     {
                         type: "horizontal-chromosome-labels",
                         server: "https://higlass.io/api/v1",

--- a/src/viewconfigs/horizontal-multivec-atac.js
+++ b/src/viewconfigs/horizontal-multivec-atac.js
@@ -120,7 +120,7 @@ export const hgDemoViewConfigAtac ={
                                 },
                                 size: { field: "PVALUE_MLOG", type: "quantitative" },
                                 color: {
-                                    value: 'gray'
+                                    value: "gray"
                                 },
                                 tooltip: [
                                     { field: "MAPPED_TRAIT", type: "nominal", alt: "Trait" },


### PR DESCRIPTION
Using the Cistrome APIs like the following, one can add bigwig tracks to the visualization:

http://develop.cistrome.org/cistrome/samples/1/track?chrom=chr1&start_pos=100&end_pos=10000&bin_length=1000